### PR TITLE
chore(specs): verblijfplaats historie in periode scenarios

### DIFF
--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -1,10 +1,10 @@
 #language: nl
 
 @gba
-Functionaliteit: raadpleeg verblijfplaats in periode
+Functionaliteit: raadpleeg verblijfplaats voorkomens in een periode
 
   Als consumer van de Historie bevragen API
-  wil ik kunnen raadplegen op welke adresseerbare objecten een persoon in een periode heeft verbleven
+  wil ik kunnen opvragen waar een persoon in een periode heeft verbleven
   zodat ik deze informatie kan gebruiken in mijn proces
 
   Achtergrond:
@@ -21,68 +21,76 @@ Functionaliteit: raadpleeg verblijfplaats in periode
     | gemeentecode (92.10) | locatiebeschrijving (12.10) |
     | 0800                 | Woonboot bij de Grote Sloot |
 
-Rule: De gevraagde velden van een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland worden geleverd als de adreshoudingperiode van de verblijfplaats in de gevraagde periode ligt of als de gevraagde periode de adreshoudingperiode geheel/deels overlapt
+Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan datum aanvang adreshouding/adres buitenland en bij aansluitend volgende adreshouding/adres buitenland, als datumVan kleiner is dan datum aanvang volgende adreshouding/adres buitenland
 
   De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
-  Komt er in de gevraagde periode alleen verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland voor, dan is de sortering gelijk aan het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
+  Komt er in de gevraagde periode alleen verblijfplaatsen voor met bekend datum aanvang adreshouding/adres buitenland, dan is de sortering gelijk aan het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
 
-  Abstract Scenario: <scenario> (geen vorige en geen volgende adreshoudingperiode)
+  Abstract Scenario: <scenario> (geen vorige en geen volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | <datum van>         |
     | datumTot            | 2011-09-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumVan | datumTot |
-    | 0800010000000001                 | Laan   | 20100818 |          |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding |
+    | 0800010000000001                 | Laan   | 20100818                 |
 
     Voorbeelden:
-    | datum van  | scenario                                                                              |
-    | 2010-09-01 | De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object       |
-    | 2010-08-01 | De gevraagde periode ligt deels in de adreshoudingperiode op een adresseerbaar object |
+    | datum van  | scenario                                                                   |
+    | 2010-09-01 | De gevraagde periode ligt na datum aanvang adreshouding                    |
+    | 2010-08-01 | datumTot van de gevraagde periode is gelijk aan datum aanvang adreshouding |
+    # 24 |--A1--     |--A1--
+    #      |---| |---|
 
-  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object (wel vorige en geen volgende adreshoudingperiode)
+  Scenario: De gevraagde periode begint op/na datum aanvang adreshouding (wel vorige en geen volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20160526                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | 2016-09-01          |
     | datumTot            | 2020-01-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumVan | datumTot |
-    | 0800010000000002                 | Luttestraat | 20160526 |          |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
+    | 0800010000000002                 | Luttestraat | 20160526                 |
+    # 24 |-A1-|--A2--
+    #          |---|
 
-  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object (geen vorige en wel volgende adreshoudingperiode)
+  Abstract Scenario: <scenario> (geen vorige verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20160526                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
-    | datumVan            | 2011-01-01          |
-    | datumTot            | 2016-01-01          |
-    | fields              | verblijfplaats      |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumVan | datumTot |
-    | 0800010000000001                 | Laan   | 20100818 | 20160526 |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | 0800010000000001                 | Laan   | 20100818                 | 20160526                         |
 
-  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object (wel vorige en wel volgende adreshoudingperiode)
+    Voorbeelden:
+    | datum tot  | scenario                                                                                        |
+    | 2016-05-25 | datumTot van de gevraagde periode is gelijk aan de dag vóór datum aanvang volgende adreshouding |
+    | 2010-08-18 | datumTot van de gevraagde periode is gelijk aan datum aanvang adreshouding                      |
+    # 24  |--A1--|--A2--     |--A1--|--A2--
+    #   |--------|       |---|
+
+  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding en datum aanvang volgende adreshouding (wel vorige verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -92,54 +100,53 @@ Rule: De gevraagde velden van een verblijfplaats van een persoon met bekend datu
     En de persoon is vervolgens ingeschreven op adres 'A3' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20201008                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | 2016-10-01          |
     | datumTot            | 2020-07-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumVan | datumTot |
-    | 0800010000000002                 | Luttestraat | 20160526 | 20201008 |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | 0800010000000002                 | Luttestraat | 20160526                 | 20201008                         |
+    # 24 |--A1--|--A2--|--A3--
+    #            |---|
 
-  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een locatie
+  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding op een locatie en datum aanvang volgende adreshouding
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A4' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
     En de persoon is vervolgens ingeschreven op adres 'A3' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20201008                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | 2016-10-01          |
     | datumTot            | 2020-07-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | locatiebeschrijving         | datumVan | datumTot |
-    | Woonboot bij de Grote Sloot | 20100818 | 20201008 |
+    | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | Woonboot bij de Grote Sloot | 20100818                 | 20201008                         |
 
-  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een buitenlands adres
+  Scenario: De gevraagde periode ligt na datum aanvang adres buitenland
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
     En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
     | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
     | 20181201                               | 6014                          |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | 2019-10-01          |
     | datumTot            | 2020-07-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving            | datumVan | datumTot |
-    | 6014      | Verenigde Staten van Amerika | 20181201 |          |
+    | land.code | land.omschrijving            | datumAanvangAdreshouding | datumAanvangVolgendeAdresBuitenland |
+    | 6014      | Verenigde Staten van Amerika | 20181201                 |                                     |
 
-  Scenario: De gevraagde periode overlapt meerdere adreshoudingperiodes
+  Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland die in de gevraagde periode liggen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -152,83 +159,151 @@ Rule: De gevraagde velden van een verblijfplaats van een persoon met bekend datu
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20200415                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | 2010-07-01          |
     | datumTot            | 2020-07-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumVan | datumTot |
-    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415 |          |
-    | 6014      | Verenigde Staten van Amerika |             |                                  |                             | 20181201 | 20200415 |
-    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526 | 20181201 |
-    |           |                              | Laan        | 0800010000000001                 |                             | 20100818 | 20160526 |
+    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangAdresBuitenland | datumAanvangVolgendeAdresBuitenland |
+    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                             |                                     |
+    | 6014      | Verenigde Staten van Amerika |             |                                  |                             |                          | 20200415                         | 20181201                    |                                     |
+    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  |                             | 20181201                            |
+    |           |                              | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                             |                                     |
 
-Rule: De gevraagde velden van een verblijfplaats van een persoon met deels/geheel onbekende datum aanvang adreshouding/adres buitenland worden geleverd als de gevraagde periode in de onzekerheidsperiode van de adreshouding ligt of als de gevraagde periode de onzekerheidsperiode geheel/deels overlapt of als de gevraagde periode in de adreshoudingperiode na de onzekerheidsperiode ligt of als de gevraagde periode deze periode geheel/deels overlapt
+Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan de eerste dag van de deels onbekende datum aanvang adreshouding/adres buitenland en bij aansluitend volgende adreshouding/adres buitenland, als datumVan kleiner is dan datum aanvang volgende adreshouding/adres buitenland
 
-  De adreshouding van een persoon heeft een onzekerheidsperiode als de datum aanvang adreshouding geheel/deels onbekend is.
-  In deze periode kan niet met zekerheid worden aangegeven of de persoon daadwerkelijk bewoner is van het adresseerbaar object.
-  Voor een datum aanvang adreshouding waarvan de dag onbekend is, loopt de onzekerheidsperiode vanaf de eerste dag tot en met de laatste dag van de betreffende maand.
-  Voor een datum aanvang adreshouding waarvan de dag en maand onbekend is, loopt de onzekerheidsperiode vanaf de eerste dag tot en met de laatste dag van het betreffende jaar.
+  Bij een datum aanvang adreshouding/adres buitenland waarvan de dag onbekend is, wordt de eerste dag van de betreffende maand als datum aanvang adreshouding/adres buitenland gehanteerd.
+  Analoog wordt, bij een datum aanvang adreshouding/adres buitenland waarvan de dag en maand onbekend is, de eerste dag van het betreffende jaar als datum aanvang adreshouding/adres buitenland gehanteerd.
 
   De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
-  In tegenstelling tot verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland, is de sortering niet hetzelfde als aflopend sorteren op datum aanvang adreshouding/adres buitenland.
-  Bij aflopende sortering zou een verblijfplaats met geheel onbekend datum aanvang adreshouding altijd de laatste verblijfplaats zijn in de verblijfplaatsen lijst.
+  In tegenstelling tot verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland, hoeft de sortering niet overeen te komen met het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
+  Dit is bijvoorbeeld het geval bij een verblijfplaats met datum aanvang adreshouding die in de onzekerheidsperiode ligt van een volgende verblijfplaats met deels onbekende datum aanvang adreshouding en de datum aanvang adreshouding ligt in de gevraagde periode.
 
-  Abstract Scenario: <scenario> (geen vorige en geen volgende adreshoudingperiode)
+  Abstract Scenario: datumTot van de gevraagde periode is gelijk aan de eerste dag van de deels onbekende datum aanvang adreshouding (geen vorige en geen volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | <datum aanvang adreshouding>       |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2007-01-01          |
+    | datumTot            | <datum tot>         |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding     |
+    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |
+
+    Voorbeelden:
+    | datum aanvang adreshouding | datum tot  |
+    | 20100800                   | 2010-08-01 |
+    | 20100000                   | 2010-01-01 |
+
+  Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats)
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100810                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160000                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | <datum van>         |
     | datumTot            | <datum tot>         |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumVan                     | datumTot |
-    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |          |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding     |
+    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |
 
     Voorbeelden:
-    | datum aanvang adreshouding | datum van  | datum tot  | scenario                                                                                                                                         |
-    | 20100800                   | 2010-08-01 | 2010-08-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object                                              |
-    | 20100800                   | 2010-07-01 | 2010-08-15 | De gevraagde periode ligt deels in de onzekerheidsperiode van de adreshouding op een adresseerbaar object                                        |
-    | 20100800                   | 2010-08-14 | 2011-01-01 | De gevraagde periode overlapt deels de onzekerheidsperiode en deels de adreshoudingperiode na de onzekerheidsperiode op een adresseerbaar object |
-    | 20100000                   | 2010-01-01 | 2010-12-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object                                              |
+    | datum van  | datum tot  | scenario                                                                                               |
+    | 2016-02-02 | 2016-12-02 | de gevraagde periode ligt in de onzekerheidsperiode van de adreshouding                                |
+    | 2016-07-01 | 2017-07-01 | datumVan ligt in de onzekerheidsperiode en datumTot ligt na de onzekerheidsperiode van de adreshouding |
+    | 2017-01-01 | 2020-01-01 | de gevraagde periode ligt na de onzekerheidsperiode van de adreshouding                                |
 
-  Scenario: De gevraagde periode overlapt meerdere adreshoudingperiodes met deels/geheel onbekend datum aanvang adreshouding/adres buitenland
+  Abstract Scenario: datumVan van de gevraagde periode ligt tussen de eerste dag van de deels onbekende datum aanvang adreshouding en datum aanvang volgende adreshouding (geen vorige en wel volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100000                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160526                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | <datum van>         |
+    | datumTot            | 2017-01-01          |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | 0800010000000002                 | Luttestraat | 20160526                 |                                  |
+    | 0800010000000001                 | Laan        | 20100000                 | 20160526                         |
+
+    Voorbeelden:
+    | datum van  |
+    | 2010-01-01 |
+    | 2016-05-25 |
+
+  Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met deels onbekende datum aanvang adreshouding/adres buitenland die in de gevraagde periode liggen
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100600                           |
     En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
-    | 0800                              | 20101026                           |
+    | 0800                              | 20100000                           |
     En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
     | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
-    | 00000000                               | 6014                          |
+    | 20101026                               | 6014                          |
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20200415                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | 2010-07-01          |
     | datumTot            | 2020-07-01          |
-    | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumVan | datumTot |
-    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415 |          |
-    | 6014      | Verenigde Staten van Amerika |             |                                  |                             | 00000000 | 20200415 |
-    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20101026 | 00000000 |
-    |           |                              | Laan        | 0800010000000001                 |                             | 20100000 | 20101026 |
+    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangAdresBuitenland | datumAanvangVolgendeAdresBuitenland |
+    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                             |                                     |
+    | 6014      | Verenigde Staten van Amerika |             |                                  |                             |                          | 20200415                         | 20101026                    |                                     |
+    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20100000                 |                                  |                             | 20101026                            |
+    |           |                              | Laan        | 0800010000000001                 |                             | 20100600                 | 20100000                         |                             |                                     |
 
-Rule: De gevraagde velden van een verblijfplaats buitenland van een persoon worden niet geleverd als de 'verblijfplaatsBinnenland' field alias wordt gebruikt
+Rule: Een verblijfplaats van een persoon met geheel onbekende datum aanvang adreshouding/adres buitenland wordt altijd geleverd
 
-  Scenario: De gevraagde periode overlapt geheel/deels de adreshoudingperiode op een buitenlands adres
+  Bij een geheel onbekende datum aanvang adreshouding/adres buitenland wordt 00010101 als datum aanvang adreshouding/adres buitenland gehanteerd.
+
+  Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met geheel onbekende datum aanvang adreshouding/adres buitenland
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 00000000                           |
+    En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100625                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+    | 20201201                               | 6014                          |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 00000000                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2010-07-01          |
+    | datumTot            | 2020-07-01          |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | land.code | land.omschrijving | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangVolgendeAdresBuitenland |
+    |           |                   | Luttestraat | 0800010000000002                 |                             | 00000000                 |                                  |                                     |
+    |           |                   |             |                                  | Woonboot bij de Grote Sloot | 20100625                 |                                  | 20201201                            |
+    |           |                   | Laan        | 0800010000000001                 |                             | 00000000                 | 20100625                         |                                     |
+
+Rule: Een verblijfplaats buitenland van een persoon wordt niet geleverd als de optionele 'exclusiefVerblijfplaatsBuitenland' parameter wordt opgegeven
+
+  Scenario: De gevraagde persoon heeft een verblijfplaats met datum aanvang adres buitenland die in de gevraagde periode ligt
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -241,15 +316,15 @@ Rule: De gevraagde velden van een verblijfplaats buitenland van een persoon word
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20200415                           |
-    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
-    | naam                | waarde                   |
-    | type                | RaadpleegMetPeriode      |
-    | burgerservicenummer | 000000024                |
-    | datumVan            | 2010-07-01               |
-    | datumTot            | 2020-07-01               |
-    | fields              | verblijfplaatsBinnenland |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                              | waarde              |
+    | type                              | RaadpleegMetPeriode |
+    | burgerservicenummer               | 000000024           |
+    | datumVan                          | 2010-07-01          |
+    | datumTot                          | 2020-07-01          |
+    | exclusiefVerblijfplaatsBuitenland | true                |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumVan | datumTot |
-    | Luttestraat | 0800010000000002                 |                             | 20200415 |          |
-    |             |                                  | Woonboot bij de Grote Sloot | 20160526 | 20181201 |
-    | Laan        | 0800010000000001                 |                             | 20100818 | 20160526 |
+    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |
+    |             |                                  | Woonboot bij de Grote Sloot | 20160526                 | 20181201                         |
+    | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -58,7 +58,7 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | naam                | waarde              |
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
-    | datumVan            | 2016-09-01          |
+    | datumVan            | <datum van>         |
     | datumTot            | 2020-01-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
     | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -89,9 +89,9 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | 0800010000000001                 | Laan   | 20100818                 | 20160526                         |
 
     Voorbeelden:
-    | datum tot  | scenario                                                                                        |
-    | 2016-05-25 | datumTot van de gevraagde periode is gelijk aan de dag vóór datum aanvang volgende adreshouding |
-    | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang adreshouding            |
+    | datum tot  | scenario                                                                             |
+    | 2016-05-26 | datumTot van de gevraagde periode is gelijk aan datum aanvang volgende adreshouding  |
+    | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang adreshouding |
     # 24  |--A1--|--A2--     |--A1--|--A2--
     #   |--------|       |---|
 

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -1,0 +1,254 @@
+#language: nl
+
+@gba
+Functionaliteit: raadpleeg verblijfplaats in periode
+
+  Als consumer van de Historie bevragen API
+  wil ik kunnen raadplegen op welke adresseerbare objecten een persoon in een periode heeft verbleven
+  zodat ik deze informatie kan gebruiken in mijn proces
+
+  Achtergrond:
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) | straatnaam (11.10) |
+    | 0800                 | 0800010000000001                         | Laan               |
+    En adres 'A2' heeft de volgende gegevens
+    | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) | straatnaam (11.10) |
+    | 0800                 | 0800010000000002                         | Luttestraat        |
+    En adres 'A3' heeft de volgende gegevens
+    | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
+    | 0800                 | 0800010000000003                         |
+    En adres 'A4' heeft de volgende gegevens
+    | gemeentecode (92.10) | locatiebeschrijving (12.10) |
+    | 0800                 | Woonboot bij de Grote Sloot |
+
+Rule: De gevraagde velden van een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland worden geleverd als de adreshoudingperiode van de verblijfplaats in de gevraagde periode ligt of als de gevraagde periode de adreshoudingperiode geheel/deels overlapt
+
+  De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
+  Komt er in de gevraagde periode alleen verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland voor, dan is de sortering gelijk aan het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
+
+  Abstract Scenario: <scenario> (geen vorige en geen volgende adreshoudingperiode)
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | <datum van>         |
+    | datumTot            | 2011-09-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat | datumVan | datumTot |
+    | 0800010000000001                 | Laan   | 20100818 |          |
+
+    Voorbeelden:
+    | datum van  | scenario                                                                              |
+    | 2010-09-01 | De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object       |
+    | 2010-08-01 | De gevraagde periode ligt deels in de adreshoudingperiode op een adresseerbaar object |
+
+  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object (wel vorige en geen volgende adreshoudingperiode)
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160526                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2016-09-01          |
+    | datumTot            | 2020-01-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat      | datumVan | datumTot |
+    | 0800010000000002                 | Luttestraat | 20160526 |          |
+
+  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object (geen vorige en wel volgende adreshoudingperiode)
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160526                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2011-01-01          |
+    | datumTot            | 2016-01-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat | datumVan | datumTot |
+    | 0800010000000001                 | Laan   | 20100818 | 20160526 |
+
+  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een adresseerbaar object (wel vorige en wel volgende adreshoudingperiode)
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160526                           |
+    En de persoon is vervolgens ingeschreven op adres 'A3' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20201008                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2016-10-01          |
+    | datumTot            | 2020-07-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat      | datumVan | datumTot |
+    | 0800010000000002                 | Luttestraat | 20160526 | 20201008 |
+
+  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een locatie
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A4' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A3' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20201008                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2016-10-01          |
+    | datumTot            | 2020-07-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | locatiebeschrijving         | datumVan | datumTot |
+    | Woonboot bij de Grote Sloot | 20100818 | 20201008 |
+
+  Scenario: De gevraagde periode ligt in de adreshoudingperiode op een buitenlands adres
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+    | 20181201                               | 6014                          |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2019-10-01          |
+    | datumTot            | 2020-07-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | land.code | land.omschrijving            | datumVan | datumTot |
+    | 6014      | Verenigde Staten van Amerika | 20181201 |          |
+
+  Scenario: De gevraagde periode overlapt meerdere adreshoudingperiodes
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160526                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+    | 20181201                               | 6014                          |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20200415                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2010-07-01          |
+    | datumTot            | 2020-07-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumVan | datumTot |
+    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415 |          |
+    | 6014      | Verenigde Staten van Amerika |             |                                  |                             | 20181201 | 20200415 |
+    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526 | 20181201 |
+    |           |                              | Laan        | 0800010000000001                 |                             | 20100818 | 20160526 |
+
+Rule: De gevraagde velden van een verblijfplaats van een persoon met deels/geheel onbekende datum aanvang adreshouding/adres buitenland worden geleverd als de onzekerheidsperiode van de adreshouding van de verblijfplaats in de gevraagde periode ligt of als de gevraagde periode de onzekerheidsperiode geheel/deels overlapt
+
+  De adreshouding van een persoon heeft een onzekerheidsperiode als de datum aanvang adreshouding geheel/deels onbekend is.
+  In deze periode kan niet met zekerheid worden aangegeven of de persoon daadwerkelijk bewoner is van het adresseerbaar object.
+  Voor een datum aanvang adreshouding waarvan de dag onbekend is, loopt de onzekerheidsperiode vanaf de eerste dag tot en met de laatste dag van de betreffende maand.
+  Voor een datum aanvang adreshouding waarvan de dag en maand onbekend is, loopt de onzekerheidsperiode vanaf de eerste dag tot en met de laatste dag van het betreffende jaar.
+
+  De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
+  In tegenstelling tot verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland, is de sortering niet hetzelfde als aflopend sorteren op datum aanvang adreshouding/adres buitenland.
+  Bij aflopende sortering zou een verblijfplaats met geheel onbekend datum aanvang adreshouding altijd de laatste verblijfplaats zijn in de verblijfplaatsen lijst.
+
+  Abstract Scenario: <scenario> (geen vorige en geen volgende adreshoudingperiode)
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | <datum aanvang adreshouding>       |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | <datum van>         |
+    | datumTot            | <datum tot>         |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat | datumVan | datumTot |
+    | 0800010000000001                 | Laan   | 20100818 |          |
+
+    Voorbeelden:
+    | datum aanvang adreshouding | datum van  | datum tot  | scenario                                                                                                  |
+    | 20100800                   | 2010-08-01 | 2010-08-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object       |
+    | 20100800                   | 2010-07-01 | 2010-08-15 | De gevraagde periode ligt deels in de onzekerheidsperiode van de adreshouding op een adresseerbaar object |
+    | 20100800                   | 2010-08-01 | 2011-01-01 | De gevraagde periode overlapt de onzekerheidsperiode van de adreshouding op een adresseerbaar object      |
+
+  Scenario: De gevraagde periode overlapt meerdere adreshoudingperiodes met deels/geheel onbekend datum aanvang adreshouding/adres buitenland
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100000                           |
+    En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20101026                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+    | 00000000                               | 6014                          |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20200415                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2010-07-01          |
+    | datumTot            | 2020-07-01          |
+    | fields              | verblijfplaats      |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumVan | datumTot |
+    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415 |          |
+    | 6014      | Verenigde Staten van Amerika |             |                                  |                             | 00000000 | 20200415 |
+    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20101026 | 00000000 |
+    |           |                              | Laan        | 0800010000000001                 |                             | 20100000 | 20101026 |
+
+Rule: De gevraagde velden van een verblijfplaats buitenland van een persoon worden niet geleverd als de 'verblijfplaatsBinnenland' field alias wordt gebruikt
+
+  Scenario: De gevraagde periode overlapt geheel/deels de adreshoudingperiode op een buitenlands adres
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A4' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160526                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+    | 20181201                               | 6014                          |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20200415                           |
+    Als gba verblijfplaatsen wordt gezocht met met de volgende parameters
+    | naam                | waarde                   |
+    | type                | RaadpleegMetPeriode      |
+    | burgerservicenummer | 000000024                |
+    | datumVan            | 2010-07-01               |
+    | datumTot            | 2020-07-01               |
+    | fields              | verblijfplaatsBinnenland |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumVan | datumTot |
+    | Luttestraat | 0800010000000002                 |                             | 20200415 |          |
+    |             |                                  | Woonboot bij de Grote Sloot | 20160526 | 20181201 |
+    | Laan        | 0800010000000001                 |                             | 20100818 | 20160526 |

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -21,7 +21,7 @@ Functionaliteit: raadpleeg verblijfplaats voorkomens in een periode
     | gemeentecode (92.10) | locatiebeschrijving (12.10) |
     | 0800                 | Woonboot bij de Grote Sloot |
 
-Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
+Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter is dan datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
 
   De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
   Komt er in de gevraagde periode alleen verblijfplaatsen voor met bekend datum aanvang adreshouding/adres buitenland, dan is de sortering gelijk aan het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
@@ -35,19 +35,19 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | type                | RaadpleegMetPeriode |
     | burgerservicenummer | 000000024           |
     | datumVan            | <datum van>         |
-    | datumTot            | 2011-09-01          |
+    | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
     | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding |
     | 0800010000000001                 | Laan   | 20100818                 |
 
     Voorbeelden:
-    | datum van  | scenario                                                                   |
-    | 2010-09-01 | De gevraagde periode ligt na datum aanvang adreshouding                    |
-    | 2010-08-01 | datumTot van de gevraagde periode is gelijk aan datum aanvang adreshouding |
+    | datum van  | datum tot  | scenario                                                                             |
+    | 2010-09-01 | 2011-09-01 | De gevraagde periode ligt na datum aanvang adreshouding                              |
+    | 2010-01-01 | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang adreshouding |
     # 24 |--A1--     |--A1--
     #      |---| |---|
 
-  Scenario: De gevraagde periode begint op/na datum aanvang adreshouding (wel vorige en geen volgende verblijfplaats)
+  Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -63,10 +63,15 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     Dan heeft de response verblijfplaatsen met de volgende gegevens
     | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
     | 0800010000000002                 | Luttestraat | 20160526                 |
-    # 24 |-A1-|--A2--
-    #          |---|
 
-  Abstract Scenario: <scenario> (geen vorige verblijfplaats)
+    Voorbeelden:
+    | datum van  | scenario                                                  |
+    | 2016-05-26 | De gevraagde periode begint op datum aanvang adreshouding |
+    | 2016-09-01 | De gevraagde periode begint na datum aanvang adreshouding |
+    # 24 |-A1-|--A2--  |-A1-|--A2--
+    #         |---|           |---|
+
+  Abstract Scenario: <scenario> (geen vorige verblijfplaats en wel volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -86,11 +91,11 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     Voorbeelden:
     | datum tot  | scenario                                                                                        |
     | 2016-05-25 | datumTot van de gevraagde periode is gelijk aan de dag vóór datum aanvang volgende adreshouding |
-    | 2010-08-18 | datumTot van de gevraagde periode is gelijk aan datum aanvang adreshouding                      |
+    | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang adreshouding            |
     # 24  |--A1--|--A2--     |--A1--|--A2--
     #   |--------|       |---|
 
-  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding en datum aanvang volgende adreshouding (wel vorige verblijfplaats)
+  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding en datum aanvang volgende adreshouding (wel vorige verblijfplaats en wel volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -143,8 +148,8 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | datumVan            | 2019-10-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving            | datumAanvangAdreshouding | datumAanvangVolgendeAdresBuitenland |
-    | 6014      | Verenigde Staten van Amerika | 20181201                 |                                     |
+    | land.code | land.omschrijving            | datumAanvangAdresBuitenland |
+    | 6014      | Verenigde Staten van Amerika | 20181201                    |
 
   Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland die in de gevraagde periode liggen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -172,7 +177,7 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  |                             | 20181201                            |
     |           |                              | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                             |                                     |
 
-Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan de eerste dag van de deels onbekende datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
+Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter is dan de eerste dag van de deels onbekende datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
 
   Bij een datum aanvang adreshouding/adres buitenland waarvan de dag onbekend is, wordt de eerste dag van de betreffende maand als datum aanvang adreshouding/adres buitenland gehanteerd. Bijvoorbeeld bij 20100800 wordt 20100801 gehanteerd.
   Analoog wordt, bij een datum aanvang adreshouding/adres buitenland waarvan de dag en maand onbekend is, de eerste dag van het betreffende jaar als datum aanvang adreshouding/adres buitenland gehanteerd. Bijvoorbeeld bij 20100000 wordt 20100101 gehanteerd.
@@ -181,7 +186,7 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
   In tegenstelling tot verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland, hoeft de sortering niet overeen te komen met het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
   Dit is bijvoorbeeld het geval bij een verblijfplaats met datum aanvang adreshouding die in de onzekerheidsperiode ligt van een volgende verblijfplaats met deels onbekende datum aanvang adreshouding en de datum aanvang adreshouding ligt in de gevraagde periode.
 
-  Abstract Scenario: datumTot van de gevraagde periode is gelijk aan de eerste dag van de deels onbekende datum aanvang adreshouding (geen vorige en geen volgende verblijfplaats)
+  Abstract Scenario: datumTot van de gevraagde periode is gelijk aan de tweede dag van de deels onbekende datum aanvang adreshouding (geen vorige en geen volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | <datum aanvang adreshouding>       |
@@ -197,8 +202,8 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
 
     Voorbeelden:
     | datum aanvang adreshouding | datum tot  |
-    | 20100800                   | 2010-08-01 |
-    | 20100000                   | 2010-01-01 |
+    | 20100800                   | 2010-08-02 |
+    | 20100000                   | 2010-01-02 |
 
   Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -245,6 +250,8 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
     | datum van  |
     | 2010-01-01 |
     | 2016-05-25 |
+    # 24 |~~A1--|--A2--  |~~A1--|--A2--
+    #    |----------|           |---|
 
   Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met deels onbekende datum aanvang adreshouding/adres buitenland die in de gevraagde periode liggen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -324,7 +331,7 @@ Rule: Een verblijfplaats buitenland van een persoon wordt niet geleverd als de o
     | datumTot                          | 2020-07-01          |
     | exclusiefVerblijfplaatsBuitenland | true                |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |
-    |             |                                  | Woonboot bij de Grote Sloot | 20160526                 | 20181201                         |
-    | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |
+    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangVolgdendeAdresBuitenland |
+    | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                                      |
+    |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  | 20181201                             |
+    | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                                      |

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -166,7 +166,7 @@ Rule: De gevraagde velden van een verblijfplaats van een persoon met bekend datu
     |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526 | 20181201 |
     |           |                              | Laan        | 0800010000000001                 |                             | 20100818 | 20160526 |
 
-Rule: De gevraagde velden van een verblijfplaats van een persoon met deels/geheel onbekende datum aanvang adreshouding/adres buitenland worden geleverd als de onzekerheidsperiode van de adreshouding van de verblijfplaats in de gevraagde periode ligt of als de gevraagde periode de onzekerheidsperiode geheel/deels overlapt
+Rule: De gevraagde velden van een verblijfplaats van een persoon met deels/geheel onbekende datum aanvang adreshouding/adres buitenland worden geleverd als de gevraagde periode in de onzekerheidsperiode van de adreshouding ligt of als de gevraagde periode de onzekerheidsperiode geheel/deels overlapt of als de gevraagde periode in de adreshoudingperiode na de onzekerheidsperiode ligt of als de gevraagde periode deze periode geheel/deels overlapt
 
   De adreshouding van een persoon heeft een onzekerheidsperiode als de datum aanvang adreshouding geheel/deels onbekend is.
   In deze periode kan niet met zekerheid worden aangegeven of de persoon daadwerkelijk bewoner is van het adresseerbaar object.
@@ -193,11 +193,11 @@ Rule: De gevraagde velden van een verblijfplaats van een persoon met deels/gehee
     | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |          |
 
     Voorbeelden:
-    | datum aanvang adreshouding | datum van  | datum tot  | scenario                                                                                                  |
-    | 20100800                   | 2010-08-01 | 2010-08-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object       |
-    | 20100800                   | 2010-07-01 | 2010-08-15 | De gevraagde periode ligt deels in de onzekerheidsperiode van de adreshouding op een adresseerbaar object |
-    | 20100800                   | 2010-08-01 | 2011-01-01 | De gevraagde periode overlapt de onzekerheidsperiode van de adreshouding op een adresseerbaar object      |
-    | 20100000                   | 2010-01-01 | 2010-12-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object       |
+    | datum aanvang adreshouding | datum van  | datum tot  | scenario                                                                                                                                         |
+    | 20100800                   | 2010-08-01 | 2010-08-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object                                              |
+    | 20100800                   | 2010-07-01 | 2010-08-15 | De gevraagde periode ligt deels in de onzekerheidsperiode van de adreshouding op een adresseerbaar object                                        |
+    | 20100800                   | 2010-08-14 | 2011-01-01 | De gevraagde periode overlapt deels de onzekerheidsperiode en deels de adreshoudingperiode na de onzekerheidsperiode op een adresseerbaar object |
+    | 20100000                   | 2010-01-01 | 2010-12-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object                                              |
 
   Scenario: De gevraagde periode overlapt meerdere adreshoudingperiodes met deels/geheel onbekend datum aanvang adreshouding/adres buitenland
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -189,14 +189,15 @@ Rule: De gevraagde velden van een verblijfplaats van een persoon met deels/gehee
     | datumTot            | <datum tot>         |
     | fields              | verblijfplaats      |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumVan | datumTot |
-    | 0800010000000001                 | Laan   | 20100818 |          |
+    | adresseerbaarObjectIdentificatie | straat | datumVan                     | datumTot |
+    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |          |
 
     Voorbeelden:
     | datum aanvang adreshouding | datum van  | datum tot  | scenario                                                                                                  |
     | 20100800                   | 2010-08-01 | 2010-08-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object       |
     | 20100800                   | 2010-07-01 | 2010-08-15 | De gevraagde periode ligt deels in de onzekerheidsperiode van de adreshouding op een adresseerbaar object |
     | 20100800                   | 2010-08-01 | 2011-01-01 | De gevraagde periode overlapt de onzekerheidsperiode van de adreshouding op een adresseerbaar object      |
+    | 20100000                   | 2010-01-01 | 2010-12-31 | De gevraagde periode ligt in de onzekerheidsperiode van de adreshouding op een adresseerbaar object       |
 
   Scenario: De gevraagde periode overlapt meerdere adreshoudingperiodes met deels/geheel onbekend datum aanvang adreshouding/adres buitenland
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -7,6 +7,14 @@ Functionaliteit: raadpleeg verblijfplaats voorkomens in een periode
   wil ik kunnen opvragen waar een persoon in een periode heeft verbleven
   zodat ik deze informatie kan gebruiken in mijn proces
 
+  De verblijfperiode van een verblijfplaats voorkomen begint op datum aanvang adreshouding/adres buitenland, oftewel datum aanvang verblijf van het verblijfplaats voorkomen
+  en eindigt indien aanwezig op de dag vóór datum aanvang verblijf van het volgende verblijfplaats voorkomen.
+
+  Het verblijfplaats voorkomen van een gevraagde persoon wordt geleverd als minimaal één dag van de gevraagde periode in de verblijfperiode ligt.
+
+  Een persoon kan in tijd maximaal op één adres hebben verbleven. Als de verblijfplaats historie van de persoon per dag (met een periode van 1 dag) wordt doorlopen,
+  dan wordt voor elke dag maximaal één verblijfplaats voorkomen geleverd.
+
   Achtergrond:
     Gegeven adres 'A1' heeft de volgende gegevens
     | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) | straatnaam (11.10) |
@@ -21,12 +29,13 @@ Functionaliteit: raadpleeg verblijfplaats voorkomens in een periode
     | gemeentecode (92.10) | locatiebeschrijving (12.10) |
     | 0800                 | Woonboot bij de Grote Sloot |
 
-Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter is dan datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
+Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als datumTot van de gevraagde periode groter is dan de datum aanvang van het verblijfplaats voorkomen en bij volgende verblijfplaats voorkomen als datumVan kleiner is dan de datum aanvang van het volgende verblijfplaats voorkomen
 
-  De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
-  Komt er in de gevraagde periode alleen verblijfplaatsen voor met bekend datum aanvang adreshouding/adres buitenland, dan is de sortering gelijk aan het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
+  De verblijfplaats voorkomens worden aflopend gesorteerd geleverd.
+  Het meest recente verblijfplaats voorkomen in de gevraagde periode is het eerste verblijfplaats voorkomen in de geleverde lijst.
+  De sortering komt overeen met het aflopend sorteren van de verblijfplaats voorkomens op datum aanvang verblijf.
 
-  Abstract Scenario: <scenario> (geen vorige en geen volgende verblijfplaats)
+  Abstract Scenario: <scenario> (geen vorige en geen volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -41,13 +50,14 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | 0800010000000001                 | Laan   | 20100818                 |
 
     Voorbeelden:
-    | datum van  | datum tot  | scenario                                                                             |
-    | 2010-09-01 | 2011-09-01 | De gevraagde periode ligt na datum aanvang adreshouding                              |
-    | 2010-01-01 | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang adreshouding |
-    # 24 |--A1--     |--A1--
-    #      |---| |---|
+    | datum van  | datum tot  | scenario                                                                                                          |
+    | 2010-09-01 | 2011-09-01 | De gevraagde periode ligt na datum aanvang verblijf van een verblijfplaats voorkomen                              |
+    | 2010-01-01 | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang verblijf van een verblijfplaats voorkomen |
+    | 2010-08-18 | 2010-08-19 | datumVan van de gevraagde periode is gelijk aan datum aanvang verblijf van een verblijfplaats voorkomen           |
+    # 24 |--A1--     |--A1-- |--A1--
+    #      |---| |---|       |-|
 
-  Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats)
+  Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -65,13 +75,13 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | 0800010000000002                 | Luttestraat | 20160526                 |
 
     Voorbeelden:
-    | datum van  | scenario                                                  |
-    | 2016-05-26 | De gevraagde periode begint op datum aanvang adreshouding |
-    | 2016-09-01 | De gevraagde periode begint na datum aanvang adreshouding |
+    | datum van  | scenario                                                                               |
+    | 2016-05-26 | De gevraagde periode begint op datum aanvang verblijf van een verblijfplaats voorkomen |
+    | 2016-09-01 | De gevraagde periode begint na datum aanvang verblijf van een verblijfplaats voorkomen |
     # 24 |-A1-|--A2--  |-A1-|--A2--
     #         |---|           |---|
 
-  Abstract Scenario: <scenario> (geen vorige verblijfplaats en wel volgende verblijfplaats)
+  Abstract Scenario: <scenario> (geen vorige en wel volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -89,13 +99,13 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | 0800010000000001                 | Laan   | 20100818                 | 20160526                         |
 
     Voorbeelden:
-    | datum tot  | scenario                                                                             |
-    | 2016-05-26 | datumTot van de gevraagde periode is gelijk aan datum aanvang volgende adreshouding  |
-    | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang adreshouding |
+    | datum tot  | scenario                                                                                                          |
+    | 2016-05-26 | datumTot van de gevraagde periode is gelijk aan datum aanvang verblijf van het volgende verblijfplaats voorkomen  |
+    | 2010-08-19 | datumTot van de gevraagde periode is gelijk aan de dag na datum aanvang verblijf van een verblijfplaats voorkomen |
     # 24  |--A1--|--A2--     |--A1--|--A2--
     #   |--------|       |---|
 
-  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding en datum aanvang volgende adreshouding (wel vorige verblijfplaats en wel volgende verblijfplaats)
+  Scenario: De gevraagde periode ligt tussen datum aanvang verblijf van een verblijfplaats voorkomen en datum aanvang verblijf van het volgende verblijfplaats voorkomen (wel vorige en wel volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -117,7 +127,7 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     # 24 |--A1--|--A2--|--A3--
     #            |---|
 
-  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding op een locatie en datum aanvang volgende adreshouding
+  Scenario: De gevraagde periode ligt tussen datum aanvang adreshouding op een locatie en datum aanvang verblijf van het volgende verblijfplaats voorkomen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A4' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -134,7 +144,7 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
     | Woonboot bij de Grote Sloot | 20100818                 | 20201008                         |
 
-  Scenario: De gevraagde periode ligt na datum aanvang adres buitenland
+  Scenario: De gevraagde periode ligt na datum aanvang adres buitenland van een verblijfplaats voorkomen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -151,7 +161,7 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     | land.code | land.omschrijving            | datumAanvangAdresBuitenland |
     | 6014      | Verenigde Staten van Amerika | 20181201                    |
 
-  Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland die in de gevraagde periode liggen
+  Scenario: De gevraagde persoon heeft meerdere verblijfplaats voorkomens met bekend datum aanvang verblijf die in de gevraagde periode liggen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100818                           |
@@ -177,16 +187,22 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  |                             | 20181201                            |
     |           |                              | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                             |                                     |
 
-Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter is dan de eerste dag van de deels onbekende datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
+Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verblijf wordt geleverd als datumTot van de gevraagde periode groter is dan de gehanteerde datum aanvang verblijf van het verblijfplaats voorkomen en bij volgende verblijfplaats voorkomen als datumVan kleiner is dan de (gehanteerde) datum aanvang verblijf van het volgende verblijfplaats voorkomen.
 
-  Bij een datum aanvang adreshouding/adres buitenland waarvan de dag onbekend is, wordt de eerste dag van de betreffende maand als datum aanvang adreshouding/adres buitenland gehanteerd. Bijvoorbeeld bij 20100800 wordt 20100801 gehanteerd.
-  Analoog wordt, bij een datum aanvang adreshouding/adres buitenland waarvan de dag en maand onbekend is, de eerste dag van het betreffende jaar als datum aanvang adreshouding/adres buitenland gehanteerd. Bijvoorbeeld bij 20100000 wordt 20100101 gehanteerd.
+  De verblijfperiode van een verblijfplaats voorkomen heeft een onzekerheidsperiode als de datum aanvang verblijf geheel/deels onbekend is.
+  Bij een datum aanvang waarvan de dag onbekend is, loopt de onzekerheidsperiode vanaf de eerste dag tot en met de laatste dag van de betreffende maand.
+  Analoog voor een datum aanvang waarvan de maand en dag onbekend is, loopt de onzekerheidsperiode vanaf de eerste dag tot en met de laatste dag van het betreffende jaar.
+  Voor een geheel onbekend datum aanvang loopt de onzekerheidsperiode vanaf 1-1-1 tot en met vandaag.
 
-  De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
-  In tegenstelling tot verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland, hoeft de sortering niet overeen te komen met het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
-  Dit is bijvoorbeeld het geval bij een verblijfplaats met datum aanvang adreshouding die in de onzekerheidsperiode ligt van een volgende verblijfplaats met deels onbekende datum aanvang adreshouding en de datum aanvang adreshouding ligt in de gevraagde periode.
+  Voor het bepalen of een verblijfplaats voorkomen met geheel/deels onbekend datum aanvang verblijf moet worden geleverd, wordt de eerste dag van de onzekerheidsperiode als datum aanvang gehanteerd,
+  mits de gehanteerde datum aanvang niet op of vóór de (gehanteerde) datum aanvang van het vorige verblijfplaats voorkomen ligt.
+  In dat geval wordt de dag na de (gehanteerde) datum aanvang van het vorige verblijfplaats voorkomen als datum aanvang verblijf gehanteerd.
 
-  Abstract Scenario: datumTot van de gevraagde periode is gelijk aan de tweede dag van de deels onbekende datum aanvang adreshouding (geen vorige en geen volgende verblijfplaats)
+  De verblijfplaats voorkomens worden aflopend gesorteerd geleverd.
+  Het meest recente verblijfplaats voorkomen in de gevraagde periode is het eerste verblijfplaats voorkomen in de geleverde lijst.
+  De sortering hoeft niet overeen te komen met het aflopend sorteren van de verblijfplaats voorkomens op datum aanvang adreshouding/adres buitenland. Dit is het geval als bijvoorbeeld de datum aanvang van een verblijfplaats voorkomen in de onzekerheidsperiode ligt van het volgende verblijfplaats voorkomen.
+
+  Abstract Scenario: datumTot van de gevraagde periode ligt op de dag na de gehanteerde datum aanvang verblijf van een verblijfplaats voorkomen met deels onbekend datum aanvang verblijf (geen vorige en geen volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | <datum aanvang adreshouding>       |
@@ -205,7 +221,7 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
     | 20100800                   | 2010-08-02 |
     | 20100000                   | 2010-01-02 |
 
-  Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats)
+  Abstract Scenario: <scenario> (wel vorige en geen volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100810                           |
@@ -223,12 +239,13 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
     | 0800010000000002                 | Luttestraat | 20160000                 |
 
     Voorbeelden:
-    | datum van  | datum tot  | scenario                                                                                               |
-    | 2016-02-02 | 2016-12-02 | de gevraagde periode ligt in de onzekerheidsperiode van de adreshouding                                |
-    | 2016-07-01 | 2017-07-01 | datumVan ligt in de onzekerheidsperiode en datumTot ligt na de onzekerheidsperiode van de adreshouding |
-    | 2017-01-01 | 2020-01-01 | de gevraagde periode ligt na de onzekerheidsperiode van de adreshouding                                |
+    | datum van  | datum tot  | scenario                                                                                                            |
+    | 2016-01-01 | 2016-07-01 | de gevraagde periode begint op de eerste dag van de onzekerheidsperiode van het verblijfplaats voorkomen            |
+    | 2016-02-02 | 2016-12-02 | de gevraagde periode ligt in de onzekerheidsperiode van het verblijfplaats voorkomen                                |
+    | 2016-07-01 | 2017-07-01 | datumVan ligt in de onzekerheidsperiode en datumTot ligt na de onzekerheidsperiode van het verblijfplaats voorkomen |
+    | 2017-01-01 | 2020-01-01 | de gevraagde periode ligt na de onzekerheidsperiode van het verblijfplaats voorkomen                                |
 
-  Abstract Scenario: datumVan van de gevraagde periode ligt tussen de eerste dag van de deels onbekende datum aanvang adreshouding en datum aanvang volgende adreshouding (geen vorige en wel volgende verblijfplaats)
+  Abstract Scenario: datum aanvang van het volgende verblijfplaats voorkomen ligt niet in de onzekerheidsperiode van een verblijfplaats voorkomen en datumVan van de gevraagde periode is groter of gelijk aan de eerste dag van de onzekerheidsperiode en kleiner dan datum aanvang volgende verblijf (geen vorige en wel volgende verblijfplaats voorkomen)
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20100000                           |
@@ -252,6 +269,45 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
     | 2016-05-25 |
     # 24 |~~A1--|--A2--  |~~A1--|--A2--
     #    |----------|           |---|
+
+  Scenario: datum aanvang van een verblijfplaats voorkomen ligt in de onzekerheidsperiode van het volgende verblijfplaats voorkomen en de gevraagde periode begint op de dag na datum aanvang van het verblijfplaats voorkomen
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160810                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160000                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2016-08-11          |
+    | datumTot            | 2018-01-01          |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
+    | 0800010000000002                 | Luttestraat | 20160000                 |
+
+  Abstract Scenario: datum aanvang van een verblijfplaats voorkomen ligt in de onzekerheidsperiode van het volgende verblijfplaats voorkomen en de gevraagde periode eindigt op de dag na datum aanvang van het verblijfplaats voorkomen
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160810                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20160000                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | <datum van>         |
+    | datumTot            | 2016-08-11          |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | 0800010000000001                 | Laan   | 20160810                 | 20160000                         |
+
+    Voorbeelden:
+    | datum van  |
+    | 2016-08-10 |
+    | 2016-01-01 |
 
   Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met deels onbekende datum aanvang adreshouding/adres buitenland die in de gevraagde periode liggen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -279,11 +335,41 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
     |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20100000                 |                                  |                             | 20101026                            |
     |           |                              | Laan        | 0800010000000001                 |                             | 20100600                 | 20100000                         |                             |                                     |
 
-Rule: Een verblijfplaats van een persoon met geheel onbekende datum aanvang adreshouding/adres buitenland wordt altijd geleverd
+  Scenario: gevraagde periode ligt in de onzekerheidsperiode van een verblijfplaats voorkomen met geheel onbekend datum aanvang verblijf en eindigt op datum aanvang van het volgende verblijfplaats voorkomen
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 00000000                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100625                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2009-07-01          |
+    | datumTot            | 2010-06-25          |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
+    | 0800010000000001                 | Laan   | 00000000                 | 20100625                         |
 
-  Bij een geheel onbekende datum aanvang adreshouding/adres buitenland wordt de eerste dag van jaar 1 (00010101) als datum aanvang adreshouding/adres buitenland gehanteerd.
+  Scenario: gevraagde periode ligt in de onzekerheidsperiode van een verblijfplaats voorkomen met geheel onbekend datum aanvang verblijf en begint op de dag na datum aanvang van het vorige verblijfplaats voorkomen
+    Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100625                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 00000000                           |
+    Als gba verblijfplaatsen wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000024           |
+    | datumVan            | 2010-06-26          |
+    | datumTot            | 2020-01-01          |
+    Dan heeft de response verblijfplaatsen met de volgende gegevens
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
+    | 0800010000000002                 | Luttestraat | 00000000                 |
 
-  Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met geheel onbekende datum aanvang adreshouding/adres buitenland
+  Scenario: De gevraagde persoon heeft meerdere verblijfplaats voorkomens met geheel onbekende datum aanvang adreshouding/adres buitenland en de gevraagde periode overlapt deze verblijfplaats voorkomens niet
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 00000000                           |
@@ -303,10 +389,8 @@ Rule: Een verblijfplaats van een persoon met geheel onbekende datum aanvang adre
     | datumVan            | 2010-07-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangVolgendeAdresBuitenland |
-    |           |                   | Luttestraat | 0800010000000002                 |                             | 00000000                 |                                  |                                     |
-    |           |                   |             |                                  | Woonboot bij de Grote Sloot | 20100625                 |                                  | 20201201                            |
-    |           |                   | Laan        | 0800010000000001                 |                             | 00000000                 | 20100625                         |                                     |
+    | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdresBuitenland |
+    | Woonboot bij de Grote Sloot | 20100625                 | 20201201                            |
 
 Rule: Een verblijfplaats buitenland van een persoon wordt niet geleverd als de optionele 'exclusiefVerblijfplaatsBuitenland' parameter wordt opgegeven
 

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -219,8 +219,8 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
     | datumVan            | <datum van>         |
     | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding     |
-    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
+    | 0800010000000002                 | Luttestraat | 20160000                 |
 
     Voorbeelden:
     | datum van  | datum tot  | scenario                                                                                               |

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -46,8 +46,8 @@ Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als d
     | datumVan            | <datum van>         |
     | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding |
-    | 0800010000000001                 | Laan   | 20100818                 |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000001                 | Laan   | 20100818                 | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum van  | datum tot  | scenario                                                                                                          |
@@ -71,8 +71,8 @@ Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als d
     | datumVan            | <datum van>         |
     | datumTot            | 2020-01-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
-    | 0800010000000002                 | Luttestraat | 20160526                 |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000002                 | Luttestraat | 20160526                 | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum van  | scenario                                                                               |
@@ -95,8 +95,8 @@ Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als d
     | datumVan            | 2010-01-01          |
     | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | 0800010000000001                 | Laan   | 20100818                 | 20160526                         |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000001                 | Laan   | 20100818                 | 20160526                         | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum tot  | scenario                                                                                                          |
@@ -122,8 +122,8 @@ Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als d
     | datumVan            | 2016-10-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | 0800010000000002                 | Luttestraat | 20160526                 | 20201008                         |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000002                 | Luttestraat | 20160526                 | 20201008                         | 0800                         | Hoogeloon, Hapert en Casteren        |
     # 24 |--A1--|--A2--|--A3--
     #            |---|
 
@@ -141,8 +141,8 @@ Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als d
     | datumVan            | 2016-10-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | Woonboot bij de Grote Sloot | 20100818                 | 20201008                         |
+    | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | Woonboot bij de Grote Sloot | 20100818                 | 20201008                         | 0800                         | Hoogeloon, Hapert en Casteren        |
 
   Scenario: De gevraagde periode ligt na datum aanvang adres buitenland van een verblijfplaats voorkomen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -181,11 +181,11 @@ Rule: Een verblijfplaats voorkomen met bekend datum aanvang wordt geleverd als d
     | datumVan            | 2010-07-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangAdresBuitenland | datumAanvangVolgendeAdresBuitenland |
-    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                             |                                     |
-    | 6014      | Verenigde Staten van Amerika |             |                                  |                             |                          | 20200415                         | 20181201                    |                                     |
-    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  |                             | 20181201                            |
-    |           |                              | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                             |                                     |
+    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangAdresBuitenland | datumAanvangVolgendeAdresBuitenland | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                             |                                     | 0800                         | Hoogeloon, Hapert en Casteren        |
+    | 6014      | Verenigde Staten van Amerika |             |                                  |                             |                          | 20200415                         | 20181201                    |                                     |                              |                                      |
+    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  |                             | 20181201                            | 0800                         | Hoogeloon, Hapert en Casteren        |
+    |           |                              | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                             |                                     | 0800                         | Hoogeloon, Hapert en Casteren        |
 
 Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verblijf wordt geleverd als datumTot van de gevraagde periode groter is dan de gehanteerde datum aanvang verblijf van het verblijfplaats voorkomen en bij volgende verblijfplaats voorkomen als datumVan kleiner is dan de (gehanteerde) datum aanvang verblijf van het volgende verblijfplaats voorkomen.
 
@@ -213,8 +213,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | 2007-01-01          |
     | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding     |
-    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding     | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000001                 | Laan   | <datum aanvang adreshouding> | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum aanvang adreshouding | datum tot  |
@@ -235,8 +235,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | <datum van>         |
     | datumTot            | <datum tot>         |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
-    | 0800010000000002                 | Luttestraat | 20160000                 |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000002                 | Luttestraat | 20160000                 | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum van  | datum tot  | scenario                                                                                                            |
@@ -259,9 +259,9 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | <datum van>         |
     | datumTot            | 2017-01-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | 0800010000000002                 | Luttestraat | 20160526                 |                                  |
-    | 0800010000000001                 | Laan        | 20100000                 | 20160526                         |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000002                 | Luttestraat | 20160526                 |                                  | 0800                         | Hoogeloon, Hapert en Casteren        |
+    | 0800010000000001                 | Laan        | 20100000                 | 20160526                         | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum van  |
@@ -284,8 +284,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | 2016-08-11          |
     | datumTot            | 2018-01-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
-    | 0800010000000002                 | Luttestraat | 20160000                 |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000002                 | Luttestraat | 20160000                 | 0800                         | Hoogeloon, Hapert en Casteren        |
 
   Abstract Scenario: datum aanvang van een verblijfplaats voorkomen ligt in de onzekerheidsperiode van het volgende verblijfplaats voorkomen en de gevraagde periode eindigt op de dag na datum aanvang van het verblijfplaats voorkomen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -301,8 +301,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | <datum van>         |
     | datumTot            | 2016-08-11          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | 0800010000000001                 | Laan   | 20160810                 | 20160000                         |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000001                 | Laan   | 20160810                 | 20160000                         | 0800                         | Hoogeloon, Hapert en Casteren        |
 
     Voorbeelden:
     | datum van  |
@@ -329,11 +329,11 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | 2010-07-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangAdresBuitenland | datumAanvangVolgendeAdresBuitenland |
-    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                             |                                     |
-    | 6014      | Verenigde Staten van Amerika |             |                                  |                             |                          | 20200415                         | 20101026                    |                                     |
-    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20100000                 |                                  |                             | 20101026                            |
-    |           |                              | Laan        | 0800010000000001                 |                             | 20100600                 | 20100000                         |                             |                                     |
+    | land.code | land.omschrijving            | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangAdresBuitenland | datumAanvangVolgendeAdresBuitenland | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    |           |                              | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                             |                                     | 0800                         | Hoogeloon, Hapert en Casteren        |
+    | 6014      | Verenigde Staten van Amerika |             |                                  |                             |                          | 20200415                         | 20101026                    |                                     |                              |                                      |
+    |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20100000                 |                                  |                             | 20101026                            | 0800                         | Hoogeloon, Hapert en Casteren        |
+    |           |                              | Laan        | 0800010000000001                 |                             | 20100600                 | 20100000                         |                             |                                     | 0800                         | Hoogeloon, Hapert en Casteren        |
 
   Scenario: gevraagde periode ligt in de onzekerheidsperiode van een verblijfplaats voorkomen met geheel onbekend datum aanvang verblijf en eindigt op datum aanvang van het volgende verblijfplaats voorkomen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -349,8 +349,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | 2009-07-01          |
     | datumTot            | 2010-06-25          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding |
-    | 0800010000000001                 | Laan   | 00000000                 | 20100625                         |
+    | adresseerbaarObjectIdentificatie | straat | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000001                 | Laan   | 00000000                 | 20100625                         | 0800                         | Hoogeloon, Hapert en Casteren        |
 
   Scenario: gevraagde periode ligt in de onzekerheidsperiode van een verblijfplaats voorkomen met geheel onbekend datum aanvang verblijf en begint op de dag na datum aanvang van het vorige verblijfplaats voorkomen
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -366,8 +366,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | 2010-06-26          |
     | datumTot            | 2020-01-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding |
-    | 0800010000000002                 | Luttestraat | 00000000                 |
+    | adresseerbaarObjectIdentificatie | straat      | datumAanvangAdreshouding | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | 0800010000000002                 | Luttestraat | 00000000                 | 0800                         | Hoogeloon, Hapert en Casteren        |
 
   Scenario: De gevraagde persoon heeft meerdere verblijfplaats voorkomens met geheel onbekende datum aanvang adreshouding/adres buitenland en de gevraagde periode overlapt deze verblijfplaats voorkomens niet
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
@@ -389,8 +389,8 @@ Rule: Een verblijfplaats voorkomen met deels/geheel onbekend datum aanvang verbl
     | datumVan            | 2010-07-01          |
     | datumTot            | 2020-07-01          |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdresBuitenland |
-    | Woonboot bij de Grote Sloot | 20100625                 | 20201201                            |
+    | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdresBuitenland | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | Woonboot bij de Grote Sloot | 20100625                 | 20201201                            | 0800                         | Hoogeloon, Hapert en Casteren        |
 
 Rule: Een verblijfplaats buitenland van een persoon wordt niet geleverd als de optionele 'exclusiefVerblijfplaatsBuitenland' parameter wordt opgegeven
 
@@ -415,7 +415,7 @@ Rule: Een verblijfplaats buitenland van een persoon wordt niet geleverd als de o
     | datumTot                          | 2020-07-01          |
     | exclusiefVerblijfplaatsBuitenland | true                |
     Dan heeft de response verblijfplaatsen met de volgende gegevens
-    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangVolgdendeAdresBuitenland |
-    | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                                      |
-    |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  | 20181201                             |
-    | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                                      |
+    | straat      | adresseerbaarObjectIdentificatie | locatiebeschrijving         | datumAanvangAdreshouding | datumAanvangVolgendeAdreshouding | datumAanvangVolgdendeAdresBuitenland | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+    | Luttestraat | 0800010000000002                 |                             | 20200415                 |                                  |                                      | 0800                         | Hoogeloon, Hapert en Casteren        |
+    |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  | 20181201                             | 0800                         | Hoogeloon, Hapert en Casteren        |
+    | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                                      | 0800                         | Hoogeloon, Hapert en Casteren        |

--- a/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/gba/overzicht-gba.feature
@@ -21,7 +21,7 @@ Functionaliteit: raadpleeg verblijfplaats voorkomens in een periode
     | gemeentecode (92.10) | locatiebeschrijving (12.10) |
     | 0800                 | Woonboot bij de Grote Sloot |
 
-Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan datum aanvang adreshouding/adres buitenland en bij aansluitend volgende adreshouding/adres buitenland, als datumVan kleiner is dan datum aanvang volgende adreshouding/adres buitenland
+Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
 
   De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
   Komt er in de gevraagde periode alleen verblijfplaatsen voor met bekend datum aanvang adreshouding/adres buitenland, dan is de sortering gelijk aan het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
@@ -172,10 +172,10 @@ Rule: Een verblijfplaats van een persoon met bekend datum aanvang adreshouding/a
     |           |                              |             |                                  | Woonboot bij de Grote Sloot | 20160526                 |                                  |                             | 20181201                            |
     |           |                              | Laan        | 0800010000000001                 |                             | 20100818                 | 20160526                         |                             |                                     |
 
-Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan de eerste dag van de deels onbekende datum aanvang adreshouding/adres buitenland en bij aansluitend volgende adreshouding/adres buitenland, als datumVan kleiner is dan datum aanvang volgende adreshouding/adres buitenland
+Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adreshouding/adres buitenland wordt geleverd als datumTot van de gevraagde periode groter of gelijk is aan de eerste dag van de deels onbekende datum aanvang adreshouding/adres buitenland en in het geval van een volgende adreshouding/adres buitenland is de datumVan kleiner dan datum aanvang volgende adreshouding/adres buitenland
 
-  Bij een datum aanvang adreshouding/adres buitenland waarvan de dag onbekend is, wordt de eerste dag van de betreffende maand als datum aanvang adreshouding/adres buitenland gehanteerd.
-  Analoog wordt, bij een datum aanvang adreshouding/adres buitenland waarvan de dag en maand onbekend is, de eerste dag van het betreffende jaar als datum aanvang adreshouding/adres buitenland gehanteerd.
+  Bij een datum aanvang adreshouding/adres buitenland waarvan de dag onbekend is, wordt de eerste dag van de betreffende maand als datum aanvang adreshouding/adres buitenland gehanteerd. Bijvoorbeeld bij 20100800 wordt 20100801 gehanteerd.
+  Analoog wordt, bij een datum aanvang adreshouding/adres buitenland waarvan de dag en maand onbekend is, de eerste dag van het betreffende jaar als datum aanvang adreshouding/adres buitenland gehanteerd. Bijvoorbeeld bij 20100000 wordt 20100101 gehanteerd.
 
   De verblijfplaatsen worden aflopend gesorteerd geleverd. De eerste verblijfplaats in de verblijfplaatsen lijst is de meest recente verblijfplaats in de gevraagde periode.
   In tegenstelling tot verblijfplaatsen met bekend datum aanvang adreshouding/adres buitenland, hoeft de sortering niet overeen te komen met het aflopend sorteren op datum aanvang adreshouding/adres buitenland.
@@ -274,7 +274,7 @@ Rule: Een verblijfplaats van een persoon met deels onbekende datum aanvang adres
 
 Rule: Een verblijfplaats van een persoon met geheel onbekende datum aanvang adreshouding/adres buitenland wordt altijd geleverd
 
-  Bij een geheel onbekende datum aanvang adreshouding/adres buitenland wordt 00010101 als datum aanvang adreshouding/adres buitenland gehanteerd.
+  Bij een geheel onbekende datum aanvang adreshouding/adres buitenland wordt de eerste dag van jaar 1 (00010101) als datum aanvang adreshouding/adres buitenland gehanteerd.
 
   Scenario: De gevraagde persoon heeft meerdere verblijfplaatsen met geheel onbekende datum aanvang adreshouding/adres buitenland
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens


### PR DESCRIPTION
vragen:

- zoals nu ontworpen levert de API alleen datum aanvang adreshouding. Is het de bedoeling dat de proxy de datumTot waarde bepaald aan de hand van de volgende verblijfplaats? In dit geval moet altijd 1 extra verblijfplaats worden geleverd. Ook moet bij gebruik van de verblijfplaatsBinnenland field alias minimaal de datum aanvang verblijfplaats buitenland veld worden geleverd om de correcte datumTot waarde te kunnen bepalen => datumAanvangVolgendeAdreshouding en datumAanvangVolgendeAdresBuitenland velden worden hiervoor toegevoegd. exclusiefVerblijfplaatsBuitenland parameter wordt toegevoegd zodat consumers kunnen aangeven dat alleen binnenlandse adressen moet worden geleverd.
- moet datum aanvang adreshouding/adres buitenland niet altijd worden geleverd? Deze velden zijn nu als optioneel gespecificeerd => niet meer relevant omdat alle verblijfplaats velden wordt geleverd
- hoe herkent een consumer dat een persoon dakloos is in een periode?

wijzigingen die worden uitgevoerd op de OpenAPI specificatie nav de scenarios:
- [ ] verwijderen fields parameter
- [ ] toevoegen exclusiefVerblijfplaatsBuitenland parameter
- [ ] toevoegen datumAanvangVolgendeAdreshouding veld aan GbaVerblijfplaats
- [ ] toevoegen datumAanvangVolgendeAdresBuitenland veld aan GbaVerblijfplaats
- [ ] verwijderen gemeenteVanInschrijving veld bij VerblijfplaatsBuitenland
- [ ] verwijderen rni veld bij Adres
- [ ] verwijderen rni veld bij Locatie
- [ ] toevoegen gemeenteVanInschrijving veld aan GbaVerblijfplaats