### PR TITLE
verblijfplaats historie wijzigingen in de OpenAPI specificatie

### DIFF
--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -472,14 +472,8 @@
           "burgerservicenummer" : {
             "$ref" : "#/components/schemas/Burgerservicenummer"
           },
-          "fields" : {
-            "maxItems" : 130,
-            "minItems" : 1,
-            "type" : "array",
-            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen\n([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields.feature)).\nDe te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields-Verblijfplaatshistorie.csv)\nwaarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.\n",
-            "items" : {
-              "$ref" : "#/components/schemas/Field"
-            }
+          "exclusiefVerblijfplaatsBuitenland" : {
+            "type" : "boolean"
           }
         },
         "discriminator" : {
@@ -500,7 +494,8 @@
             "peildatum" : {
               "type" : "string",
               "description" : "De datum waarop de resource wordt opgevraagd.\n",
-              "format" : "date"
+              "format" : "date",
+              "example" : "1964-09-24"
             }
           }
         } ]
@@ -515,12 +510,14 @@
             "datumVan" : {
               "type" : "string",
               "description" : "De begindatum van de periode waarover de resource wordt opgevraagd.\n",
-              "format" : "date"
+              "format" : "date",
+              "example" : "1964-09-24"
             },
             "datumTot" : {
               "type" : "string",
               "description" : "De einddatum van de periode waarover de resource wordt opgevraagd.\n",
-              "format" : "date"
+              "format" : "date",
+              "example" : "1964-09-24"
             }
           }
         } ]
@@ -624,7 +621,13 @@
             "datumAanvangAdresBuitenland" : {
               "$ref" : "#/components/schemas/GbaDatum"
             },
+            "datumAanvangVolgendeAdresBuitenland" : {
+              "$ref" : "#/components/schemas/GbaDatum"
+            },
             "datumAanvangAdreshouding" : {
+              "$ref" : "#/components/schemas/GbaDatum"
+            },
+            "datumAanvangVolgendeAdreshouding" : {
               "$ref" : "#/components/schemas/GbaDatum"
             },
             "functieAdres" : {
@@ -633,8 +636,14 @@
             "naamOpenbareRuimte" : {
               "$ref" : "#/components/schemas/NaamOpenbareRuimte"
             },
+            "gemeenteVanInschrijving" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
             "rni" : {
               "$ref" : "#/components/schemas/RniDeelnemer"
+            },
+            "inOnderzoekVolgendeVerblijfplaats" : {
+              "$ref" : "#/components/schemas/GbaInOnderzoek"
             }
           }
         } ]
@@ -851,11 +860,6 @@
         "type" : "string",
         "example" : "555555021"
       },
-      "Field" : {
-        "pattern" : "^[a-zA-Z0-9\\._]{1,200}$",
-        "type" : "string",
-        "description" : "Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld \"burgerservicenummer\", \"geboorte.datum\", \"partners.naam.voornamen\".\n"
-      },
       "GbaDatum" : {
         "pattern" : "^[0-9]{8}$",
         "type" : "string",
@@ -983,6 +987,168 @@
         "properties" : {
           "datum" : {
             "$ref" : "#/components/schemas/GbaDatum"
+          }
+        }
+      }
+    },
+    "responses" : {
+      "400" : {
+        "description" : "Bad Request",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/BadRequestFoutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+              "title" : "Ten minste één parameter moet worden opgegeven.",
+              "status" : 400,
+              "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "paramsRequired",
+              "invalidParams" : [ {
+                "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                "name" : "huisnummer",
+                "code" : "integer",
+                "reason" : "Waarde is geen geldig getal."
+              } ]
+            }
+          }
+        }
+      },
+      "401" : {
+        "description" : "Unauthorized",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+              "title" : "Niet correct geauthenticeerd.",
+              "status" : 401,
+              "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "authentication"
+            }
+          }
+        }
+      },
+      "403" : {
+        "description" : "Forbidden",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+              "title" : "U bent niet geautoriseerd voor deze operatie.",
+              "status" : 403,
+              "detail" : "The server understood the request, but is refusing to fulfill it.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "autorisation"
+            }
+          }
+        }
+      },
+      "406" : {
+        "description" : "Not Acceptable",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+              "title" : "Gevraagde contenttype wordt niet ondersteund.",
+              "status" : 406,
+              "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "notAcceptable"
+            }
+          }
+        }
+      },
+      "415" : {
+        "description" : "Unsupported Media Type",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16",
+              "title" : "Unsupported Media Type",
+              "status" : 415,
+              "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "unsupported"
+            }
+          }
+        }
+      },
+      "429" : {
+        "description" : "Too Many Requests",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+              "title" : "Too many request",
+              "status" : 429,
+              "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "tooManyRequests"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal Server Error",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+              "title" : "Interne server fout.",
+              "status" : 500,
+              "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "serverError"
+            }
+          }
+        }
+      },
+      "503" : {
+        "description" : "Service Unavailable",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+              "title" : "Bronservice BRP is tijdelijk niet beschikbaar.",
+              "status" : 503,
+              "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "notAvailable"
+            }
+          }
+        }
+      },
+      "default" : {
+        "description" : "Er is een onverwachte fout opgetreden",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            }
           }
         }
       }

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -10,7 +10,7 @@
       "name" : "European Union Public License, version 1.2 (EUPL-1.2)",
       "url" : "https://eupl.eu/1.2/nl/"
     },
-    "version" : "2.0.0 (develop)"
+    "version" : "2.0.0"
   },
   "servers" : [ {
     "url" : "https://www.haalcentraal.nl/haalcentraal/api/brphistorie",
@@ -222,208 +222,6 @@
           }
         }
       }
-    },
-    "/partnerhistorie" : {
-      "post" : {
-        "tags" : [ "BRP historie bevragen" ],
-        "description" : "Raadpleeg de partnerhistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.\nDe meest actuele partner staat bovenaan.\n\nZoek met burgerservicenummer\n",
-        "operationId" : "Partnerhistorie",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/HistorieQuery"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Zoekactie geslaagd\n",
-            "headers" : {
-              "warning" : {
-                "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PartnerhistorieQueryResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
-                  "title" : "Ten minste één parameter moet worden opgegeven.",
-                  "status" : 400,
-                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "paramsRequired",
-                  "invalidParams" : [ {
-                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
-                    "name" : "huisnummer",
-                    "code" : "integer",
-                    "reason" : "Waarde is geen geldig getal."
-                  } ]
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
-                  "title" : "Niet correct geauthenticeerd.",
-                  "status" : 401,
-                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "authentication"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
-                  "title" : "U bent niet geautoriseerd voor deze operatie.",
-                  "status" : 403,
-                  "detail" : "The server understood the request, but is refusing to fulfill it.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "autorisation"
-                }
-              }
-            }
-          },
-          "406" : {
-            "description" : "Not Acceptable",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
-                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
-                  "status" : 406,
-                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
-                  "title" : "Interne server fout.",
-                  "status" : 500,
-                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "serverError"
-                }
-              }
-            }
-          },
-          "503" : {
-            "description" : "Service Unavailable",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
-                  "title" : "Bronservice BRP is tijdelijk niet beschikbaar.",
-                  "status" : 503,
-                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "notAvailable"
-                }
-              }
-            }
-          },
-          "default" : {
-            "description" : "Er is een onverwachte fout opgetreden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components" : {
@@ -434,24 +232,7 @@
           "verblijfplaatsen" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/GbaVerblijfplaats"
-            }
-          },
-          "geheimhoudingPersoonsgegevens" : {
-            "$ref" : "#/components/schemas/GbaGeheimhoudingPersoonsgegevens"
-          },
-          "opschortingBijhouding" : {
-            "$ref" : "#/components/schemas/GbaOpschortingBijhouding"
-          }
-        }
-      },
-      "PartnerhistorieQueryResponse" : {
-        "type" : "object",
-        "properties" : {
-          "partners" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/GbaPartner"
+              "$ref" : "#/components/schemas/GbaVerblijfplaatsVoorkomen"
             }
           },
           "geheimhoudingPersoonsgegevens" : {
@@ -473,7 +254,8 @@
             "$ref" : "#/components/schemas/Burgerservicenummer"
           },
           "exclusiefVerblijfplaatsBuitenland" : {
-            "type" : "boolean"
+            "type" : "boolean",
+            "description" : "consumers die niet zijn geautoriseerd voor verblijfplaats buitenland kunnen deze parameter gebruiken om alleen binnenlandse verblijfplaats voorkomens te vragen\n"
           }
         },
         "discriminator" : {
@@ -606,7 +388,7 @@
         },
         "description" : "Details over fouten in opgegeven parameters"
       },
-      "GbaVerblijfplaats" : {
+      "GbaVerblijfplaatsVoorkomen" : {
         "allOf" : [ {
           "$ref" : "#/components/schemas/GbaVerblijfplaatsBeperkt"
         }, {
@@ -647,6 +429,36 @@
             }
           }
         } ]
+      },
+      "GbaGeheimhoudingPersoonsgegevens" : {
+        "type" : "integer"
+      },
+      "GbaOpschortingBijhouding" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/OpschortingBijhoudingBasis"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "datum" : {
+              "$ref" : "#/components/schemas/GbaDatum"
+            }
+          },
+          "description" : "* **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.\n"
+        } ]
+      },
+      "OpschortingBijhoudingBasis" : {
+        "type" : "object",
+        "properties" : {
+          "reden" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          }
+        },
+        "description" : "* **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.\n"
+      },
+      "Burgerservicenummer" : {
+        "pattern" : "^[0-9]{9}$",
+        "type" : "string",
+        "example" : "555555021"
       },
       "GbaVerblijfplaatsBeperkt" : {
         "type" : "object",
@@ -765,101 +577,6 @@
         "description" : "Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.\n",
         "example" : "0518200000366054"
       },
-      "NaamOpenbareRuimte" : {
-        "maxLength" : 80,
-        "type" : "string"
-      },
-      "GbaGeheimhoudingPersoonsgegevens" : {
-        "type" : "integer"
-      },
-      "GbaOpschortingBijhouding" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/OpschortingBijhoudingBasis"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "datum" : {
-              "$ref" : "#/components/schemas/GbaDatum"
-            }
-          },
-          "description" : "* **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.\n"
-        } ]
-      },
-      "OpschortingBijhoudingBasis" : {
-        "type" : "object",
-        "properties" : {
-          "reden" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          }
-        },
-        "description" : "* **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.\n"
-      },
-      "GbaPartner" : {
-        "type" : "object",
-        "properties" : {
-          "burgerservicenummer" : {
-            "$ref" : "#/components/schemas/Burgerservicenummer"
-          },
-          "geslacht" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "soortVerbintenis" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "naam" : {
-            "$ref" : "#/components/schemas/GbaNaamBasis"
-          },
-          "geboorte" : {
-            "$ref" : "#/components/schemas/GbaGeboorte"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/GbaInOnderzoek"
-          },
-          "aangaanHuwelijkPartnerschap" : {
-            "$ref" : "#/components/schemas/GbaAangaanHuwelijkPartnerschap"
-          },
-          "ontbindingHuwelijkPartnerschap" : {
-            "$ref" : "#/components/schemas/GbaOntbindingHuwelijkPartnerschap"
-          }
-        }
-      },
-      "GbaAangaanHuwelijkPartnerschap" : {
-        "type" : "object",
-        "properties" : {
-          "datum" : {
-            "$ref" : "#/components/schemas/GbaDatum"
-          },
-          "land" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "plaats" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          }
-        },
-        "description" : "Gegevens over de voltrekking van het huwelijk of het aangaan van het geregistreerd partnerschap.\n* **datum** - De datum waarop het huwelijk is voltrokken of het partnerschap is aangegaan.\n* **land** - Het land waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.\n* **plaats** - De gemeente waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel \"Gemeenten\" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats.\n"
-      },
-      "GbaOntbindingHuwelijkPartnerschap" : {
-        "type" : "object",
-        "properties" : {
-          "datum" : {
-            "$ref" : "#/components/schemas/GbaDatum"
-          },
-          "land" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "plaats" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "reden" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          }
-        }
-      },
-      "Burgerservicenummer" : {
-        "pattern" : "^[0-9]{9}$",
-        "type" : "string",
-        "example" : "555555021"
-      },
       "GbaDatum" : {
         "pattern" : "^[0-9]{8}$",
         "type" : "string",
@@ -879,6 +596,10 @@
             "example" : "Nederland"
           }
         }
+      },
+      "NaamOpenbareRuimte" : {
+        "maxLength" : 80,
+        "type" : "string"
       },
       "RniDeelnemer" : {
         "type" : "object",
@@ -905,87 +626,6 @@
             "type" : "string"
           },
           "datumIngangOnderzoek" : {
-            "$ref" : "#/components/schemas/GbaDatum"
-          }
-        }
-      },
-      "GbaNaamBasis" : {
-        "type" : "object",
-        "properties" : {
-          "voornamen" : {
-            "$ref" : "#/components/schemas/Voornamen"
-          },
-          "adellijkeTitelPredicaat" : {
-            "$ref" : "#/components/schemas/AdellijkeTitelPredicaatType"
-          },
-          "voorvoegsel" : {
-            "$ref" : "#/components/schemas/Voorvoegsel"
-          },
-          "geslachtsnaam" : {
-            "$ref" : "#/components/schemas/Geslachtsnaam"
-          }
-        }
-      },
-      "Voornamen" : {
-        "maxLength" : 200,
-        "pattern" : "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$",
-        "type" : "string",
-        "description" : "De verzameling namen voor de geslachtsnaam, gescheiden door spaties.\n"
-      },
-      "AdellijkeTitelPredicaatType" : {
-        "description" : "Wordt gevuld met waarden uit de landelijke tabel 'Adellijke titel/predicaat'. De property soort geeft aan of het een 'predicaat' of een 'titel' is.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Waardetabel"
-        }, {
-          "properties" : {
-            "soort" : {
-              "$ref" : "#/components/schemas/AdellijkeTitelPredicaatSoort"
-            }
-          },
-          "example" : {
-            "value" : {
-              "code" : "JV",
-              "omschrijving" : "jonkvrouw",
-              "soort" : "predicaat"
-            }
-          }
-        } ]
-      },
-      "AdellijkeTitelPredicaatSoort" : {
-        "type" : "string",
-        "enum" : [ "titel", "predicaat" ]
-      },
-      "Voorvoegsel" : {
-        "maxLength" : 10,
-        "pattern" : "^[a-zA-Z \\']{1,10}$",
-        "type" : "string",
-        "example" : "de"
-      },
-      "Geslachtsnaam" : {
-        "pattern" : "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$",
-        "type" : "string",
-        "description" : "De achternaam van een persoon.\n",
-        "example" : "Vries"
-      },
-      "GbaGeboorte" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/GbaGeboorteBeperkt"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "land" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "plaats" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            }
-          }
-        } ]
-      },
-      "GbaGeboorteBeperkt" : {
-        "type" : "object",
-        "properties" : {
-          "datum" : {
             "$ref" : "#/components/schemas/GbaDatum"
           }
         }

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -8,7 +8,7 @@ info:
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen
   license:
-    name: European Union Public License, version 1.2 (EUPL-1.2)
+    name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/
   version: 2.0.0 (develop)
 servers:
@@ -94,8 +94,8 @@ paths:
                 type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
                 title: U bent niet geautoriseerd voor deze operatie.
                 status: 403
-                detail: The server understood the request, but is refusing to fulfill
-                  it.
+                detail: "The server understood the request, but is refusing to fulfill\
+                  \ it."
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
         "406":
@@ -252,8 +252,8 @@ paths:
                 type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
                 title: U bent niet geautoriseerd voor deze operatie.
                 status: 403
-                detail: The server understood the request, but is refusing to fulfill
-                  it.
+                detail: "The server understood the request, but is refusing to fulfill\
+                  \ it."
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
         "406":
@@ -369,17 +369,8 @@ components:
           type: string
         burgerservicenummer:
           $ref: '#/components/schemas/Burgerservicenummer'
-        fields:
-          maxItems: 130
-          minItems: 1
-          type: array
-          description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen
-            ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields.feature)).
-            De te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields-Verblijfplaatshistorie.csv)
-            waarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.
-          items:
-            $ref: '#/components/schemas/Field'
+        exclusiefVerblijfplaatsBuitenland:
+          type: boolean
       discriminator:
         propertyName: type
         mapping:
@@ -397,6 +388,7 @@ components:
             description: |
               De datum waarop de resource wordt opgevraagd.
             format: date
+            example: 1964-09-24
     RaadpleegMetPeriode:
       required:
       - datumTot
@@ -410,11 +402,13 @@ components:
             description: |
               De begindatum van de periode waarover de resource wordt opgevraagd.
             format: date
+            example: 1964-09-24
           datumTot:
             type: string
             description: |
               De einddatum van de periode waarover de resource wordt opgevraagd.
             format: date
+            example: 1964-09-24
     BadRequestFoutbericht:
       allOf:
       - $ref: '#/components/schemas/Foutbericht'
@@ -434,7 +428,7 @@ components:
           description: Link naar meer informatie over deze fout
           format: uri
         title:
-          pattern: ^[a-zA-Z0-9À-ž \.\-]{1,80}$
+          pattern: "^[a-zA-Z0-9À-ž \\.\\-]{1,80}$"
           type: string
           description: Beschrijving van de fout
         status:
@@ -443,7 +437,7 @@ components:
           type: integer
           description: Http status code
         detail:
-          pattern: ^[a-zA-Z0-9À-ž \.\-\(\)\,]{1,200}$
+          pattern: "^[a-zA-Z0-9À-ž \\.\\-\\(\\)\\,]{1,200}$"
           type: string
           description: Details over de fout
         instance:
@@ -452,30 +446,30 @@ components:
           format: uri
         code:
           minLength: 1
-          pattern: ^[a-zA-Z0-9]{1,25}$
+          pattern: "^[a-zA-Z0-9]{1,25}$"
           type: string
           description: Systeemcode die het type fout aangeeft
-      description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
+      description: "Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807)."
     InvalidParams:
       type: object
       properties:
         type:
           type: string
           format: uri
-          example: https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer
+          example: "https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer"
         name:
-          pattern: ^[a-zA-Z0-9\.,_]{1,30}$
+          pattern: "^[a-zA-Z0-9\\.,_]{1,30}$"
           type: string
           description: Naam van de parameter
           example: huisnummer
         code:
           minLength: 1
-          pattern: ^[a-zA-Z0-9\.,_]{1,25}$
+          pattern: "^[a-zA-Z0-9\\.,_]{1,25}$"
           type: string
           description: Systeemcode die het type fout aangeeft
           example: integer
         reason:
-          pattern: ^[a-zA-Z0-9\.,_ ]{1,80}$
+          pattern: "^[a-zA-Z0-9\\.,_ ]{1,80}$"
           type: string
           description: Beschrijving van de fout op de parameterwaarde
           example: Waarde is geen geldig getal.
@@ -491,14 +485,22 @@ components:
             $ref: '#/components/schemas/NummeraanduidingIdentificatie'
           datumAanvangAdresBuitenland:
             $ref: '#/components/schemas/GbaDatum'
+          datumAanvangVolgendeAdresBuitenland:
+            $ref: '#/components/schemas/GbaDatum'
           datumAanvangAdreshouding:
+            $ref: '#/components/schemas/GbaDatum'
+          datumAanvangVolgendeAdreshouding:
             $ref: '#/components/schemas/GbaDatum'
           functieAdres:
             $ref: '#/components/schemas/Waardetabel'
           naamOpenbareRuimte:
             $ref: '#/components/schemas/NaamOpenbareRuimte'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
           rni:
             $ref: '#/components/schemas/RniDeelnemer'
+          inOnderzoekVolgendeVerblijfplaats:
+            $ref: '#/components/schemas/GbaInOnderzoek'
     GbaVerblijfplaatsBeperkt:
       type: object
       properties:
@@ -540,26 +542,26 @@ components:
         Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
       example: 14
     Huisletter:
-      pattern: ^[a-zA-Z]{1}$
+      pattern: "^[a-zA-Z]{1}$"
       type: string
       description: |
         Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
       example: a
     Huisnummertoevoeging:
-      pattern: ^[a-zA-Z0-9 \-]{1,4}$
+      pattern: "^[a-zA-Z0-9 \\-]{1,4}$"
       type: string
       description: |
         Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
       example: bis
     Postcode:
-      pattern: ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$
+      pattern: "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$"
       type: string
       description: |
         De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
       example: 2341SX
     Woonplaats:
       title: woonplaats naam
-      pattern: ^[a-zA-Z0-9À-ž \(\)\,\.\-\']{1,80}$
+      pattern: "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$"
       type: string
       description: |
         Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.
@@ -581,7 +583,7 @@ components:
       type: string
       description: |
         Het tweede deel van een buitenlands adres. Vaak is dit een combinatie van woonplaats eventueel in combinatie met de postcode.
-      example: Washington, DC 20500
+      example: "Washington, DC 20500"
     Regel3:
       maxLength: 35
       type: string
@@ -589,13 +591,13 @@ components:
         Het derde deel van een buitenlands adres is optioneel. Het gaat om een of meer geografische gebieden van het adres in het buitenland.
       example: Selangor
     AdresseerbaarObjectIdentificatie:
-      pattern: ^[0-9]{16}$
+      pattern: "^[0-9]{16}$"
       type: string
       description: |
         De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
       example: "0226010000038820"
     NummeraanduidingIdentificatie:
-      pattern: ^[0-9]{16}$
+      pattern: "^[0-9]{16}$"
       type: string
       description: |
         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
@@ -666,27 +668,22 @@ components:
         reden:
           $ref: '#/components/schemas/Waardetabel'
     Burgerservicenummer:
-      pattern: ^[0-9]{9}$
+      pattern: "^[0-9]{9}$"
       type: string
       example: "555555021"
-    Field:
-      pattern: ^[a-zA-Z0-9\._]{1,200}$
-      type: string
-      description: |
-        Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld "burgerservicenummer", "geboorte.datum", "partners.naam.voornamen".
     GbaDatum:
-      pattern: ^[0-9]{8}$
+      pattern: "^[0-9]{8}$"
       type: string
       example: "20180700"
     Waardetabel:
       type: object
       properties:
         code:
-          pattern: ^[a-zA-Z0-9 \.]+$
+          pattern: "^[a-zA-Z0-9 \\.]+$"
           type: string
           example: "6030"
         omschrijving:
-          pattern: ^[a-zA-Z0-9À-ž \'\,\(\)\.\-]{1,200}$
+          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
           type: string
           example: Nederland
     RniDeelnemer:
@@ -697,7 +694,7 @@ components:
         omschrijvingVerdrag:
           $ref: '#/components/schemas/OmschrijvingVerdrag'
     OmschrijvingVerdrag:
-      pattern: ^[a-zA-Z0-9À-ž \.\-\']{1,50}$
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,50}$"
       type: string
       description: |
         Omschrijving van het verdrag op basis waarvan een zusterorganisatie in het buitenland de gegevens bij de RNI-deelnemer heeft aangeleverd.
@@ -708,7 +705,7 @@ components:
       type: object
       properties:
         aanduidingGegevensInOnderzoek:
-          pattern: ^[0-9]{6}$
+          pattern: "^[0-9]{6}$"
           type: string
         datumIngangOnderzoek:
           $ref: '#/components/schemas/GbaDatum'
@@ -725,7 +722,7 @@ components:
           $ref: '#/components/schemas/Geslachtsnaam'
     Voornamen:
       maxLength: 200
-      pattern: ^[a-zA-Z0-9À-ž \.\-\']{1,200}$
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
       type: string
       description: |
         De verzameling namen voor de geslachtsnaam, gescheiden door spaties.
@@ -749,11 +746,11 @@ components:
       - predicaat
     Voorvoegsel:
       maxLength: 10
-      pattern: ^[a-zA-Z \']{1,10}$
+      pattern: "^[a-zA-Z \\']{1,10}$"
       type: string
       example: de
     Geslachtsnaam:
-      pattern: ^[a-zA-Z0-9À-ž \.\-\']{1,200}$
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
       type: string
       description: |
         De achternaam van een persoon.
@@ -772,18 +769,145 @@ components:
       properties:
         datum:
           $ref: '#/components/schemas/GbaDatum'
+  responses:
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestFoutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+            title: Ten minste één parameter moet worden opgegeven.
+            status: 400
+            detail: The request could not be understood by the server due to malformed
+              syntax. The client SHOULD NOT repeat the request without modification.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: paramsRequired
+            invalidParams:
+            - type: https://www.vng.nl/realisatie/api/validaties/integer
+              name: huisnummer
+              code: integer
+              reason: Waarde is geen geldig getal.
+    "401":
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+            title: Niet correct geauthenticeerd.
+            status: 401
+            detail: The request requires user authentication. The response MUST include
+              a WWW-Authenticate header field (section 14.47) containing a challenge
+              applicable to the requested resource.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: authentication
+    "403":
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+            title: U bent niet geautoriseerd voor deze operatie.
+            status: 403
+            detail: "The server understood the request, but is refusing to fulfill\
+              \ it."
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: autorisation
+    "406":
+      description: Not Acceptable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+            title: Gevraagde contenttype wordt niet ondersteund.
+            status: 406
+            detail: The resource identified by the request is only capable of generating
+              response entities which have content characteristics not acceptable
+              according to thr accept headers sent in the request
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAcceptable
+    "415":
+      description: Unsupported Media Type
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
+            title: Unsupported Media Type
+            status: 415
+            detail: The server is refusing the request because the entity of the request
+              is in a format not supported by the requested resource for the requested
+              method.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: unsupported
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+            title: Too many request
+            status: 429
+            detail: The user has sent too many requests in a given amount of time
+              (rate limiting).
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: tooManyRequests
+    "500":
+      description: Internal Server Error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+            title: Interne server fout.
+            status: 500
+            detail: The server encountered an unexpected condition which prevented
+              it from fulfilling the request.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: serverError
+    "503":
+      description: Service Unavailable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+            title: Bronservice BRP is tijdelijk niet beschikbaar.
+            status: 503
+            detail: The service is currently unable to handle the request due to a
+              temporary overloading or maintenance of the server.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAvailable
+    default:
+      description: Er is een onverwachte fout opgetreden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
   headers:
     warning:
       schema:
         maxLength: 500
         type: string
-        description: zie RFC 7234. In het geval een major versie wordt uitgefaseerd,
-          gebruiken we warn-code 299 ("Miscellaneous Persistent Warning") en het API
-          end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd
-          door de warn-text met de human-readable waarschuwing
-        example: '299 https://service.../api/.../v1 "Deze versie van de API is verouderd
-          en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
-          hier de documentatie: https://omgevingswet.../api/.../v1".'
+        description: "zie RFC 7234. In het geval een major versie wordt uitgefaseerd,\
+          \ gebruiken we warn-code 299 (\"Miscellaneous Persistent Warning\") en het\
+          \ API end-point (inclusief versienummer) als de warn-agent van de warning,\
+          \ gevolgd door de warn-text met de human-readable waarschuwing"
+        example: "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd\
+          \ en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie\
+          \ hier de documentatie: https://omgevingswet.../api/.../v1\"."
     X_Rate_Limit_Limit:
       schema:
         type: integer

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/
-  version: 2.0.0 (develop)
+  version: 2.0.0
 servers:
 - url: https://www.haalcentraal.nl/haalcentraal/api/brphistorie
   description: APILAB testserver historie
@@ -176,164 +176,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Foutbericht'
-  /partnerhistorie:
-    post:
-      tags:
-      - BRP historie bevragen
-      description: |
-        Raadpleeg de partnerhistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.
-        De meest actuele partner staat bovenaan.
-
-        Zoek met burgerservicenummer
-      operationId: Partnerhistorie
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/HistorieQuery'
-      responses:
-        "200":
-          description: |
-            Zoekactie geslaagd
-          headers:
-            warning:
-              $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PartnerhistorieQueryResponse'
-        "400":
-          description: Bad Request
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/BadRequestFoutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
-                title: Ten minste één parameter moet worden opgegeven.
-                status: 400
-                detail: The request could not be understood by the server due to malformed
-                  syntax. The client SHOULD NOT repeat the request without modification.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: paramsRequired
-                invalidParams:
-                - type: https://www.vng.nl/realisatie/api/validaties/integer
-                  name: huisnummer
-                  code: integer
-                  reason: Waarde is geen geldig getal.
-        "401":
-          description: Unauthorized
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
-                title: Niet correct geauthenticeerd.
-                status: 401
-                detail: The request requires user authentication. The response MUST
-                  include a WWW-Authenticate header field (section 14.47) containing
-                  a challenge applicable to the requested resource.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: authentication
-        "403":
-          description: Forbidden
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
-                title: U bent niet geautoriseerd voor deze operatie.
-                status: 403
-                detail: "The server understood the request, but is refusing to fulfill\
-                  \ it."
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: autorisation
-        "406":
-          description: Not Acceptable
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
-                title: Gevraagde contenttype wordt niet ondersteund.
-                status: 406
-                detail: The resource identified by the request is only capable of
-                  generating response entities which have content characteristics
-                  not acceptable according to thr accept headers sent in the request
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: notAcceptable
-        "415":
-          description: Unsupported Media Type
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
-        "500":
-          description: Internal Server Error
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
-                title: Interne server fout.
-                status: 500
-                detail: The server encountered an unexpected condition which prevented
-                  it from fulfilling the request.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: serverError
-        "503":
-          description: Service Unavailable
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
-                title: Bronservice BRP is tijdelijk niet beschikbaar.
-                status: 503
-                detail: The service is currently unable to handle the request due
-                  to a temporary overloading or maintenance of the server.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: notAvailable
-        default:
-          description: Er is een onverwachte fout opgetreden
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
 components:
   schemas:
     VerblijfplaatshistorieQueryResponse:
@@ -342,18 +184,7 @@ components:
         verblijfplaatsen:
           type: array
           items:
-            $ref: '#/components/schemas/GbaVerblijfplaats'
-        geheimhoudingPersoonsgegevens:
-          $ref: '#/components/schemas/GbaGeheimhoudingPersoonsgegevens'
-        opschortingBijhouding:
-          $ref: '#/components/schemas/GbaOpschortingBijhouding'
-    PartnerhistorieQueryResponse:
-      type: object
-      properties:
-        partners:
-          type: array
-          items:
-            $ref: '#/components/schemas/GbaPartner'
+            $ref: '#/components/schemas/GbaVerblijfplaatsVoorkomen'
         geheimhoudingPersoonsgegevens:
           $ref: '#/components/schemas/GbaGeheimhoudingPersoonsgegevens'
         opschortingBijhouding:
@@ -371,6 +202,8 @@ components:
           $ref: '#/components/schemas/Burgerservicenummer'
         exclusiefVerblijfplaatsBuitenland:
           type: boolean
+          description: |
+            consumers die niet zijn geautoriseerd voor verblijfplaats buitenland kunnen deze parameter gebruiken om alleen binnenlandse verblijfplaats voorkomens te vragen
       discriminator:
         propertyName: type
         mapping:
@@ -474,7 +307,7 @@ components:
           description: Beschrijving van de fout op de parameterwaarde
           example: Waarde is geen geldig getal.
       description: Details over fouten in opgegeven parameters
-    GbaVerblijfplaats:
+    GbaVerblijfplaatsVoorkomen:
       allOf:
       - $ref: '#/components/schemas/GbaVerblijfplaatsBeperkt'
       - type: object
@@ -501,6 +334,28 @@ components:
             $ref: '#/components/schemas/RniDeelnemer'
           inOnderzoekVolgendeVerblijfplaats:
             $ref: '#/components/schemas/GbaInOnderzoek'
+    GbaGeheimhoudingPersoonsgegevens:
+      type: integer
+    GbaOpschortingBijhouding:
+      allOf:
+      - $ref: '#/components/schemas/OpschortingBijhoudingBasis'
+      - type: object
+        properties:
+          datum:
+            $ref: '#/components/schemas/GbaDatum'
+        description: |
+          * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
+    OpschortingBijhoudingBasis:
+      type: object
+      properties:
+        reden:
+          $ref: '#/components/schemas/Waardetabel'
+      description: |
+        * **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.
+    Burgerservicenummer:
+      pattern: "^[0-9]{9}$"
+      type: string
+      example: "555555021"
     GbaVerblijfplaatsBeperkt:
       type: object
       properties:
@@ -602,75 +457,6 @@ components:
       description: |
         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
       example: "0518200000366054"
-    NaamOpenbareRuimte:
-      maxLength: 80
-      type: string
-    GbaGeheimhoudingPersoonsgegevens:
-      type: integer
-    GbaOpschortingBijhouding:
-      allOf:
-      - $ref: '#/components/schemas/OpschortingBijhoudingBasis'
-      - type: object
-        properties:
-          datum:
-            $ref: '#/components/schemas/GbaDatum'
-        description: |
-          * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
-    OpschortingBijhoudingBasis:
-      type: object
-      properties:
-        reden:
-          $ref: '#/components/schemas/Waardetabel'
-      description: |
-        * **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.
-    GbaPartner:
-      type: object
-      properties:
-        burgerservicenummer:
-          $ref: '#/components/schemas/Burgerservicenummer'
-        geslacht:
-          $ref: '#/components/schemas/Waardetabel'
-        soortVerbintenis:
-          $ref: '#/components/schemas/Waardetabel'
-        naam:
-          $ref: '#/components/schemas/GbaNaamBasis'
-        geboorte:
-          $ref: '#/components/schemas/GbaGeboorte'
-        inOnderzoek:
-          $ref: '#/components/schemas/GbaInOnderzoek'
-        aangaanHuwelijkPartnerschap:
-          $ref: '#/components/schemas/GbaAangaanHuwelijkPartnerschap'
-        ontbindingHuwelijkPartnerschap:
-          $ref: '#/components/schemas/GbaOntbindingHuwelijkPartnerschap'
-    GbaAangaanHuwelijkPartnerschap:
-      type: object
-      properties:
-        datum:
-          $ref: '#/components/schemas/GbaDatum'
-        land:
-          $ref: '#/components/schemas/Waardetabel'
-        plaats:
-          $ref: '#/components/schemas/Waardetabel'
-      description: |
-        Gegevens over de voltrekking van het huwelijk of het aangaan van het geregistreerd partnerschap.
-        * **datum** - De datum waarop het huwelijk is voltrokken of het partnerschap is aangegaan.
-        * **land** - Het land waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
-        * **plaats** - De gemeente waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel "Gemeenten" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats.
-    GbaOntbindingHuwelijkPartnerschap:
-      type: object
-      properties:
-        datum:
-          $ref: '#/components/schemas/GbaDatum'
-        land:
-          $ref: '#/components/schemas/Waardetabel'
-        plaats:
-          $ref: '#/components/schemas/Waardetabel'
-        reden:
-          $ref: '#/components/schemas/Waardetabel'
-    Burgerservicenummer:
-      pattern: "^[0-9]{9}$"
-      type: string
-      example: "555555021"
     GbaDatum:
       pattern: "^[0-9]{8}$"
       type: string
@@ -686,6 +472,9 @@ components:
           pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
           type: string
           example: Nederland
+    NaamOpenbareRuimte:
+      maxLength: 80
+      type: string
     RniDeelnemer:
       type: object
       properties:
@@ -708,66 +497,6 @@ components:
           pattern: "^[0-9]{6}$"
           type: string
         datumIngangOnderzoek:
-          $ref: '#/components/schemas/GbaDatum'
-    GbaNaamBasis:
-      type: object
-      properties:
-        voornamen:
-          $ref: '#/components/schemas/Voornamen'
-        adellijkeTitelPredicaat:
-          $ref: '#/components/schemas/AdellijkeTitelPredicaatType'
-        voorvoegsel:
-          $ref: '#/components/schemas/Voorvoegsel'
-        geslachtsnaam:
-          $ref: '#/components/schemas/Geslachtsnaam'
-    Voornamen:
-      maxLength: 200
-      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
-      type: string
-      description: |
-        De verzameling namen voor de geslachtsnaam, gescheiden door spaties.
-    AdellijkeTitelPredicaatType:
-      description: |
-        Wordt gevuld met waarden uit de landelijke tabel 'Adellijke titel/predicaat'. De property soort geeft aan of het een 'predicaat' of een 'titel' is.
-      allOf:
-      - $ref: '#/components/schemas/Waardetabel'
-      - properties:
-          soort:
-            $ref: '#/components/schemas/AdellijkeTitelPredicaatSoort'
-        example:
-          value:
-            code: JV
-            omschrijving: jonkvrouw
-            soort: predicaat
-    AdellijkeTitelPredicaatSoort:
-      type: string
-      enum:
-      - titel
-      - predicaat
-    Voorvoegsel:
-      maxLength: 10
-      pattern: "^[a-zA-Z \\']{1,10}$"
-      type: string
-      example: de
-    Geslachtsnaam:
-      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
-      type: string
-      description: |
-        De achternaam van een persoon.
-      example: Vries
-    GbaGeboorte:
-      allOf:
-      - $ref: '#/components/schemas/GbaGeboorteBeperkt'
-      - type: object
-        properties:
-          land:
-            $ref: '#/components/schemas/Waardetabel'
-          plaats:
-            $ref: '#/components/schemas/Waardetabel'
-    GbaGeboorteBeperkt:
-      type: object
-      properties:
-        datum:
           $ref: '#/components/schemas/GbaDatum'
   responses:
     "400":

--- a/specificatie/gba-openapi.yaml
+++ b/specificatie/gba-openapi.yaml
@@ -79,18 +79,7 @@ components:
         verblijfplaatsen:
           type: array
           items:
-            $ref: 'verblijfplaats.yaml#/components/schemas/GbaVerblijfplaats'
-        geheimhoudingPersoonsgegevens:
-          $ref: 'persoon.yaml#/components/schemas/GbaGeheimhoudingPersoonsgegevens'
-        opschortingBijhouding:
-          $ref: 'opschortingbijhouding.yaml#/components/schemas/GbaOpschortingBijhouding'
-    PartnerhistorieQueryResponse:
-      type: object
-      properties:
-        partners:
-          type: array
-          items:
-            $ref: 'partner.yaml#/components/schemas/GbaPartner'
+            $ref: 'verblijfplaats-voorkomen.yaml#/components/schemas/GbaVerblijfplaatsVoorkomen'
         geheimhoudingPersoonsgegevens:
           $ref: 'persoon.yaml#/components/schemas/GbaGeheimhoudingPersoonsgegevens'
         opschortingBijhouding:

--- a/specificatie/gba-openapi.yaml
+++ b/specificatie/gba-openapi.yaml
@@ -8,7 +8,7 @@ info:
                 API voor het zoeken en raadplegen van historische verblijfplaatsen, partners, nationaliteiten en verblijfstitels uit de BRP (inclusief de RNI).
 
                 Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/tree/v1.0.0/features) voor nadere toelichting.
-  version: 2.0.0 (develop)
+  version: 2.0.0
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen
   license:
@@ -48,56 +48,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VerblijfplaatshistorieQueryResponse"
-        '400':
-          $ref: "common.yaml#/components/responses/400"
-        '401':
-          $ref: "common.yaml#/components/responses/401"
-        '403':
-          $ref: "common.yaml#/components/responses/403"
-        '406':
-          $ref: "common.yaml#/components/responses/406"
-        '415':
-          $ref: 'common.yaml#/components/responses/415'
-        '429':
-          $ref: "common.yaml#/components/responses/429"
-        '500':
-          $ref: "common.yaml#/components/responses/500"
-        '503':
-          $ref: "common.yaml#/components/responses/503"
-        'default':
-          $ref: "common.yaml#/components/responses/default"
-      tags:
-        - BRP historie bevragen
-  /partnerhistorie:
-    post:
-      description: |
-        Raadpleeg de partnerhistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.
-        De meest actuele partner staat bovenaan.
-
-        Zoek met burgerservicenummer
-      operationId: Partnerhistorie
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "openapi.yaml#/components/schemas/HistorieQuery"
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            warning:
-              $ref: "common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Reset"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PartnerhistorieQueryResponse'
         '400':
           $ref: "common.yaml#/components/responses/400"
         '401':

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -438,14 +438,8 @@
           "burgerservicenummer" : {
             "$ref" : "#/components/schemas/Burgerservicenummer"
           },
-          "fields" : {
-            "maxItems" : 130,
-            "minItems" : 1,
-            "type" : "array",
-            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen\n([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields.feature)).\nDe te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields-Verblijfplaatshistorie.csv)\nwaarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.\n",
-            "items" : {
-              "$ref" : "#/components/schemas/Field"
-            }
+          "exclusiefVerblijfplaatsBuitenland" : {
+            "type" : "boolean"
           }
         },
         "discriminator" : {
@@ -617,11 +611,6 @@
         "type" : "string",
         "example" : "555555021"
       },
-      "Field" : {
-        "pattern" : "^[a-zA-Z0-9\\._]{1,200}$",
-        "type" : "string",
-        "description" : "Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld \"burgerservicenummer\", \"geboorte.datum\", \"partners.naam.voornamen\".\n"
-      },
       "AbstractVerblijfplaats" : {
         "required" : [ "type" ],
         "type" : "object",
@@ -650,9 +639,6 @@
           "properties" : {
             "verblijfadres" : {
               "$ref" : "#/components/schemas/VerblijfadresBuitenland"
-            },
-            "gemeenteVanInschrijving" : {
-              "$ref" : "#/components/schemas/Waardetabel"
             },
             "datumVan" : {
               "$ref" : "#/components/schemas/AbstractDatum"
@@ -742,12 +728,15 @@
             },
             "datumVan" : {
               "type" : "boolean"
+            },
+            "datumTot" : {
+              "type" : "boolean"
             }
           }
         } ]
       },
       "Adres" : {
-        "description" : "Gegevens over het adres van een persoon.\n* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n* **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.\n* **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.\n* **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.\n",
+        "description" : "Gegevens over het adres van een persoon.\n* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n* **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.\n* **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.\n* **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.\n* **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.\n",
         "allOf" : [ {
           "$ref" : "#/components/schemas/AbstractVerblijfplaats"
         }, {
@@ -779,9 +768,6 @@
             },
             "inOnderzoek" : {
               "$ref" : "#/components/schemas/AdresInOnderzoek"
-            },
-            "rni" : {
-              "$ref" : "#/components/schemas/RniDeelnemer"
             }
           }
         } ]
@@ -924,6 +910,9 @@
             "datumVan" : {
               "type" : "boolean"
             },
+            "datumTot" : {
+              "type" : "boolean"
+            },
             "nummeraanduidingIdentificatie" : {
               "type" : "boolean"
             },
@@ -968,6 +957,9 @@
             },
             "datumVan" : {
               "type" : "boolean"
+            },
+            "datumTot" : {
+              "type" : "boolean"
             }
           }
         } ]
@@ -999,9 +991,6 @@
             },
             "inOnderzoek" : {
               "$ref" : "#/components/schemas/LocatieInOnderzoek"
-            },
-            "rni" : {
-              "$ref" : "#/components/schemas/RniDeelnemer"
             }
           }
         } ]
@@ -1048,6 +1037,9 @@
               "type" : "boolean"
             },
             "datumVan" : {
+              "type" : "boolean"
+            },
+            "datumTot" : {
               "type" : "boolean"
             },
             "functieAdres" : {
@@ -1210,21 +1202,6 @@
           }
         } ]
       },
-      "Waardetabel" : {
-        "type" : "object",
-        "properties" : {
-          "code" : {
-            "pattern" : "^[a-zA-Z0-9 \\.]+$",
-            "type" : "string",
-            "example" : "6030"
-          },
-          "omschrijving" : {
-            "pattern" : "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$",
-            "type" : "string",
-            "example" : "Nederland"
-          }
-        }
-      },
       "AbstractDatum" : {
         "required" : [ "langFormaat", "type" ],
         "type" : "object",
@@ -1357,6 +1334,21 @@
           },
           "omschrijvingVerdrag" : {
             "$ref" : "#/components/schemas/OmschrijvingVerdrag"
+          }
+        }
+      },
+      "Waardetabel" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "pattern" : "^[a-zA-Z0-9 \\.]+$",
+            "type" : "string",
+            "example" : "6030"
+          },
+          "omschrijving" : {
+            "pattern" : "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$",
+            "type" : "string",
+            "example" : "Nederland"
           }
         }
       },
@@ -1512,6 +1504,168 @@
             }
           }
         } ]
+      }
+    },
+    "responses" : {
+      "400" : {
+        "description" : "Bad Request",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/BadRequestFoutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
+              "title" : "Ten minste één parameter moet worden opgegeven.",
+              "status" : 400,
+              "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "paramsRequired",
+              "invalidParams" : [ {
+                "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
+                "name" : "huisnummer",
+                "code" : "integer",
+                "reason" : "Waarde is geen geldig getal."
+              } ]
+            }
+          }
+        }
+      },
+      "401" : {
+        "description" : "Unauthorized",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
+              "title" : "Niet correct geauthenticeerd.",
+              "status" : 401,
+              "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "authentication"
+            }
+          }
+        }
+      },
+      "403" : {
+        "description" : "Forbidden",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
+              "title" : "U bent niet geautoriseerd voor deze operatie.",
+              "status" : 403,
+              "detail" : "The server understood the request, but is refusing to fulfill it.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "autorisation"
+            }
+          }
+        }
+      },
+      "406" : {
+        "description" : "Not Acceptable",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
+              "title" : "Gevraagde contenttype wordt niet ondersteund.",
+              "status" : 406,
+              "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "notAcceptable"
+            }
+          }
+        }
+      },
+      "415" : {
+        "description" : "Unsupported Media Type",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16",
+              "title" : "Unsupported Media Type",
+              "status" : 415,
+              "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "unsupported"
+            }
+          }
+        }
+      },
+      "429" : {
+        "description" : "Too Many Requests",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+              "title" : "Too many request",
+              "status" : 429,
+              "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "tooManyRequests"
+            }
+          }
+        }
+      },
+      "500" : {
+        "description" : "Internal Server Error",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
+              "title" : "Interne server fout.",
+              "status" : 500,
+              "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "serverError"
+            }
+          }
+        }
+      },
+      "503" : {
+        "description" : "Service Unavailable",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            },
+            "example" : {
+              "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
+              "title" : "Bronservice BRP is tijdelijk niet beschikbaar.",
+              "status" : 503,
+              "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
+              "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
+              "code" : "notAvailable"
+            }
+          }
+        }
+      },
+      "default" : {
+        "description" : "Er is een onverwachte fout opgetreden",
+        "content" : {
+          "application/problem+json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Foutbericht"
+            }
+          }
+        }
       }
     },
     "headers" : {

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -723,9 +723,6 @@
             "type" : {
               "type" : "boolean"
             },
-            "gemeenteVanInschrijving" : {
-              "type" : "boolean"
-            },
             "datumVan" : {
               "type" : "boolean"
             },

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -10,7 +10,7 @@
       "name" : "European Union Public License, version 1.2 (EUPL-1.2)",
       "url" : "https://eupl.eu/1.2/nl/"
     },
-    "version" : "2.0.0 (develop)"
+    "version" : "2.0.0"
   },
   "servers" : [ {
     "url" : "https://www.haalcentraal.nl/haalcentraal/api/brphistorie",
@@ -222,208 +222,6 @@
           }
         }
       }
-    },
-    "/partnerhistorie" : {
-      "post" : {
-        "tags" : [ "BRP historie bevragen" ],
-        "description" : "Raadpleeg de partnerhistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.\nDe meest actuele partner staat bovenaan.\n\nZoek met burgerservicenummer\n",
-        "operationId" : "Partnerhistorie",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/HistorieQuery"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Zoekactie geslaagd\n",
-            "headers" : {
-              "warning" : {
-                "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PartnerhistorieQueryResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/BadRequestFoutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1",
-                  "title" : "Ten minste één parameter moet worden opgegeven.",
-                  "status" : 400,
-                  "detail" : "The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "paramsRequired",
-                  "invalidParams" : [ {
-                    "type" : "https://www.vng.nl/realisatie/api/validaties/integer",
-                    "name" : "huisnummer",
-                    "code" : "integer",
-                    "reason" : "Waarde is geen geldig getal."
-                  } ]
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2",
-                  "title" : "Niet correct geauthenticeerd.",
-                  "status" : 401,
-                  "detail" : "The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "authentication"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4",
-                  "title" : "U bent niet geautoriseerd voor deze operatie.",
-                  "status" : 403,
-                  "detail" : "The server understood the request, but is refusing to fulfill it.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "autorisation"
-                }
-              }
-            }
-          },
-          "406" : {
-            "description" : "Not Acceptable",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7",
-                  "title" : "Gevraagde contenttype wordt niet ondersteund.",
-                  "status" : 406,
-                  "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1",
-                  "title" : "Interne server fout.",
-                  "status" : 500,
-                  "detail" : "The server encountered an unexpected condition which prevented it from fulfilling the request.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "serverError"
-                }
-              }
-            }
-          },
-          "503" : {
-            "description" : "Service Unavailable",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4",
-                  "title" : "Bronservice BRP is tijdelijk niet beschikbaar.",
-                  "status" : 503,
-                  "detail" : "The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "notAvailable"
-                }
-              }
-            }
-          },
-          "default" : {
-            "description" : "Er is een onverwachte fout opgetreden",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components" : {
@@ -439,7 +237,8 @@
             "$ref" : "#/components/schemas/Burgerservicenummer"
           },
           "exclusiefVerblijfplaatsBuitenland" : {
-            "type" : "boolean"
+            "type" : "boolean",
+            "description" : "consumers die niet zijn geautoriseerd voor verblijfplaats buitenland kunnen deze parameter gebruiken om alleen binnenlandse verblijfplaats voorkomens te vragen\n"
           }
         },
         "discriminator" : {
@@ -494,24 +293,7 @@
           "verblijfplaatsen" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/AbstractVerblijfplaats"
-            }
-          },
-          "geheimhoudingPersoonsgegevens" : {
-            "$ref" : "#/components/schemas/GeheimhoudingPersoonsgegevens"
-          },
-          "opschortingBijhouding" : {
-            "$ref" : "#/components/schemas/OpschortingBijhouding"
-          }
-        }
-      },
-      "PartnerhistorieQueryResponse" : {
-        "type" : "object",
-        "properties" : {
-          "partners" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Partner"
+              "$ref" : "#/components/schemas/AbstractVerblijfplaatsVoorkomen"
             }
           },
           "geheimhoudingPersoonsgegevens" : {
@@ -611,7 +393,7 @@
         "type" : "string",
         "example" : "555555021"
       },
-      "AbstractVerblijfplaats" : {
+      "AbstractVerblijfplaatsVoorkomen" : {
         "required" : [ "type" ],
         "type" : "object",
         "properties" : {
@@ -619,21 +401,21 @@
             "type" : "string"
           }
         },
-        "description" : "Gegevens over het verblijf of de woonlocatie van een persoon.\n",
+        "description" : "Gegevens over het verblijfplaats voorkomen van een persoon.\n",
         "discriminator" : {
           "propertyName" : "type",
           "mapping" : {
-            "VerblijfplaatsBuitenland" : "#/components/schemas/VerblijfplaatsBuitenland",
-            "Adres" : "#/components/schemas/Adres",
-            "VerblijfplaatsOnbekend" : "#/components/schemas/VerblijfplaatsOnbekend",
-            "Locatie" : "#/components/schemas/Locatie"
+            "VerblijfplaatsBuitenland" : "#/components/schemas/VerblijfplaatsBuitenlandVoorkomen",
+            "Adres" : "#/components/schemas/AdresVoorkomen",
+            "VerblijfplaatsOnbekend" : "#/components/schemas/VerblijfplaatsOnbekendVoorkomen",
+            "Locatie" : "#/components/schemas/LocatieVoorkomen"
           }
         }
       },
-      "VerblijfplaatsBuitenland" : {
-        "description" : "* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n* **land** - land waar de persoon is overleden. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.\n",
+      "VerblijfplaatsBuitenlandVoorkomen" : {
+        "description" : "* **land** - land waar de persoon is overleden. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.\n",
         "allOf" : [ {
-          "$ref" : "#/components/schemas/AbstractVerblijfplaats"
+          "$ref" : "#/components/schemas/AbstractVerblijfplaatsVoorkomen"
         }, {
           "type" : "object",
           "properties" : {
@@ -647,13 +429,215 @@
               "$ref" : "#/components/schemas/AbstractDatum"
             },
             "inOnderzoek" : {
-              "$ref" : "#/components/schemas/VerblijfplaatsBuitenlandInOnderzoek"
+              "$ref" : "#/components/schemas/VerblijfplaatsBuitenlandVoorkomenInOnderzoek"
             },
             "rni" : {
               "$ref" : "#/components/schemas/RniDeelnemer"
             }
           }
         } ]
+      },
+      "VerblijfplaatsBuitenlandVoorkomenInOnderzoek" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/InOnderzoek"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "type" : {
+              "type" : "boolean"
+            },
+            "datumVan" : {
+              "type" : "boolean"
+            },
+            "datumTot" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "AdresVoorkomen" : {
+        "description" : "Gegevens over het adres voorkomen van een persoon.\n* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n* **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.\n* **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.\n* **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.\n* **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.\n",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AbstractVerblijfplaatsVoorkomen"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "verblijfadres" : {
+              "$ref" : "#/components/schemas/VerblijfadresBinnenland"
+            },
+            "functieAdres" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "adresseerbaarObjectIdentificatie" : {
+              "$ref" : "#/components/schemas/AdresseerbaarObjectIdentificatie"
+            },
+            "nummeraanduidingIdentificatie" : {
+              "$ref" : "#/components/schemas/NummeraanduidingIdentificatie"
+            },
+            "gemeenteVanInschrijving" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "datumVan" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            },
+            "datumTot" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            },
+            "indicatieVastgesteldVerblijftNietOpAdres" : {
+              "$ref" : "#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres"
+            },
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/AdresVoorkomenInOnderzoek"
+            }
+          }
+        } ]
+      },
+      "AdresVoorkomenInOnderzoek" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/InOnderzoek"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "type" : {
+              "type" : "boolean"
+            },
+            "datumVan" : {
+              "type" : "boolean"
+            },
+            "datumTot" : {
+              "type" : "boolean"
+            },
+            "nummeraanduidingIdentificatie" : {
+              "type" : "boolean"
+            },
+            "adresseerbaarObjectIdentificatie" : {
+              "type" : "boolean"
+            },
+            "functieAdres" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "VerblijfplaatsOnbekendVoorkomen" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AbstractVerblijfplaatsVoorkomen"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "datumVan" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            },
+            "datumTot" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            },
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/VerblijfplaatsOnbekendVoorkomenInOnderzoek"
+            },
+            "rni" : {
+              "$ref" : "#/components/schemas/RniDeelnemer"
+            }
+          }
+        } ]
+      },
+      "VerblijfplaatsOnbekendVoorkomenInOnderzoek" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/InOnderzoek"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "type" : {
+              "type" : "boolean"
+            },
+            "datumVan" : {
+              "type" : "boolean"
+            },
+            "datumTot" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "LocatieVoorkomen" : {
+        "description" : "* **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.\n* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/AbstractVerblijfplaatsVoorkomen"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "datumVan" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            },
+            "datumTot" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            },
+            "functieAdres" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "verblijfadres" : {
+              "$ref" : "#/components/schemas/VerblijfadresLocatie"
+            },
+            "gemeenteVanInschrijving" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
+            "indicatieVastgesteldVerblijftNietOpAdres" : {
+              "$ref" : "#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres"
+            },
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/LocatieVoorkomenInOnderzoek"
+            }
+          }
+        } ]
+      },
+      "LocatieVoorkomenInOnderzoek" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/InOnderzoek"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "type" : {
+              "type" : "boolean"
+            },
+            "gemeenteVanInschrijving" : {
+              "type" : "boolean"
+            },
+            "datumVan" : {
+              "type" : "boolean"
+            },
+            "datumTot" : {
+              "type" : "boolean"
+            },
+            "functieAdres" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "GeheimhoudingPersoonsgegevens" : {
+        "type" : "boolean",
+        "description" : "Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.\n"
+      },
+      "OpschortingBijhouding" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/OpschortingBijhoudingBasis"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "datum" : {
+              "$ref" : "#/components/schemas/AbstractDatum"
+            }
+          },
+          "description" : "* **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.\n"
+        } ]
+      },
+      "OpschortingBijhoudingBasis" : {
+        "type" : "object",
+        "properties" : {
+          "reden" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          }
+        },
+        "description" : "* **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.\n"
       },
       "VerblijfadresBuitenland" : {
         "type" : "object",
@@ -709,491 +693,6 @@
               "type" : "boolean"
             },
             "land" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "VerblijfplaatsBuitenlandInOnderzoek" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "type" : {
-              "type" : "boolean"
-            },
-            "datumVan" : {
-              "type" : "boolean"
-            },
-            "datumTot" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "Adres" : {
-        "description" : "Gegevens over het adres van een persoon.\n* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n* **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.\n* **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.\n* **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.\n* **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/AbstractVerblijfplaats"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "verblijfadres" : {
-              "$ref" : "#/components/schemas/VerblijfadresBinnenland"
-            },
-            "functieAdres" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "adresseerbaarObjectIdentificatie" : {
-              "$ref" : "#/components/schemas/AdresseerbaarObjectIdentificatie"
-            },
-            "nummeraanduidingIdentificatie" : {
-              "$ref" : "#/components/schemas/NummeraanduidingIdentificatie"
-            },
-            "gemeenteVanInschrijving" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "datumVan" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            },
-            "datumTot" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            },
-            "indicatieVastgesteldVerblijftNietOpAdres" : {
-              "$ref" : "#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres"
-            },
-            "inOnderzoek" : {
-              "$ref" : "#/components/schemas/AdresInOnderzoek"
-            }
-          }
-        } ]
-      },
-      "VerblijfadresBinnenland" : {
-        "type" : "object",
-        "properties" : {
-          "officieleStraatnaam" : {
-            "$ref" : "#/components/schemas/OfficieleStraatnaam"
-          },
-          "korteStraatnaam" : {
-            "$ref" : "#/components/schemas/KorteStraatnaam"
-          },
-          "huisnummer" : {
-            "$ref" : "#/components/schemas/Huisnummer"
-          },
-          "huisletter" : {
-            "$ref" : "#/components/schemas/Huisletter"
-          },
-          "huisnummertoevoeging" : {
-            "$ref" : "#/components/schemas/Huisnummertoevoeging"
-          },
-          "aanduidingBijHuisnummer" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "postcode" : {
-            "$ref" : "#/components/schemas/Postcode"
-          },
-          "woonplaats" : {
-            "$ref" : "#/components/schemas/Woonplaats"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/VerblijfadresBinnenlandInOnderzoek"
-          }
-        }
-      },
-      "OfficieleStraatnaam" : {
-        "maxLength" : 80,
-        "type" : "string",
-        "description" : "De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG).\n"
-      },
-      "KorteStraatnaam" : {
-        "maxLength" : 24,
-        "type" : "string",
-        "description" : "De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG), zo nodig verkort tot maximaal 24 tekens, of de straatnaam van een niet-BAG adres.\n"
-      },
-      "Huisnummer" : {
-        "maximum" : 99999,
-        "minimum" : 1,
-        "type" : "integer",
-        "description" : "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.\n",
-        "example" : 14
-      },
-      "Huisletter" : {
-        "pattern" : "^[a-zA-Z]{1}$",
-        "type" : "string",
-        "description" : "Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.\n",
-        "example" : "a"
-      },
-      "Huisnummertoevoeging" : {
-        "pattern" : "^[a-zA-Z0-9 \\-]{1,4}$",
-        "type" : "string",
-        "description" : "Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.\n",
-        "example" : "bis"
-      },
-      "Postcode" : {
-        "pattern" : "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$",
-        "type" : "string",
-        "description" : "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.\n",
-        "example" : "2341SX"
-      },
-      "Woonplaats" : {
-        "title" : "woonplaats naam",
-        "pattern" : "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$",
-        "type" : "string",
-        "description" : "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.\n",
-        "example" : "Duiven"
-      },
-      "VerblijfadresBinnenlandInOnderzoek" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "aanduidingBijHuisnummer" : {
-              "type" : "boolean"
-            },
-            "huisletter" : {
-              "type" : "boolean"
-            },
-            "huisnummer" : {
-              "type" : "boolean"
-            },
-            "huisnummertoevoeging" : {
-              "type" : "boolean"
-            },
-            "officieleStraatnaam" : {
-              "type" : "boolean"
-            },
-            "postcode" : {
-              "type" : "boolean"
-            },
-            "korteStraatnaam" : {
-              "type" : "boolean"
-            },
-            "woonplaats" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "AdresseerbaarObjectIdentificatie" : {
-        "pattern" : "^[0-9]{16}$",
-        "type" : "string",
-        "description" : "De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.\n",
-        "example" : "0226010000038820"
-      },
-      "NummeraanduidingIdentificatie" : {
-        "pattern" : "^[0-9]{16}$",
-        "type" : "string",
-        "description" : "Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.\n",
-        "example" : "0518200000366054"
-      },
-      "IndicatieVastgesteldVerblijftNietOpAdres" : {
-        "type" : "boolean",
-        "description" : "Geeft aan dat is vastgesteld dat de persoon niet meer op de geregistreerde adres/locatie staat ingeschreven.\n"
-      },
-      "AdresInOnderzoek" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "type" : {
-              "type" : "boolean"
-            },
-            "gemeenteVanInschrijving" : {
-              "type" : "boolean"
-            },
-            "datumVan" : {
-              "type" : "boolean"
-            },
-            "datumTot" : {
-              "type" : "boolean"
-            },
-            "nummeraanduidingIdentificatie" : {
-              "type" : "boolean"
-            },
-            "adresseerbaarObjectIdentificatie" : {
-              "type" : "boolean"
-            },
-            "functieAdres" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "VerblijfplaatsOnbekend" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/AbstractVerblijfplaats"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "datumVan" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            },
-            "datumTot" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            },
-            "inOnderzoek" : {
-              "$ref" : "#/components/schemas/VerblijfplaatsOnbekendInOnderzoek"
-            },
-            "rni" : {
-              "$ref" : "#/components/schemas/RniDeelnemer"
-            }
-          }
-        } ]
-      },
-      "VerblijfplaatsOnbekendInOnderzoek" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "type" : {
-              "type" : "boolean"
-            },
-            "datumVan" : {
-              "type" : "boolean"
-            },
-            "datumTot" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "Locatie" : {
-        "description" : "* **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.\n* **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.\n* **landVanWaarIngeschreven** : het land waar de persoon woonde voor (her)vestiging in Nederland. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/AbstractVerblijfplaats"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "datumVan" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            },
-            "datumTot" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            },
-            "functieAdres" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "verblijfadres" : {
-              "$ref" : "#/components/schemas/VerblijfadresLocatie"
-            },
-            "gemeenteVanInschrijving" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "indicatieVastgesteldVerblijftNietOpAdres" : {
-              "$ref" : "#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres"
-            },
-            "inOnderzoek" : {
-              "$ref" : "#/components/schemas/LocatieInOnderzoek"
-            }
-          }
-        } ]
-      },
-      "VerblijfadresLocatie" : {
-        "type" : "object",
-        "properties" : {
-          "locatiebeschrijving" : {
-            "$ref" : "#/components/schemas/Locatiebeschrijving"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/VerblijfadresLocatieInOnderzoek"
-          }
-        }
-      },
-      "Locatiebeschrijving" : {
-        "maxLength" : 35,
-        "type" : "string",
-        "description" : "Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.\n",
-        "example" : "Naast de derde brug"
-      },
-      "VerblijfadresLocatieInOnderzoek" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "locatiebeschrijving" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "LocatieInOnderzoek" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "type" : {
-              "type" : "boolean"
-            },
-            "gemeenteVanInschrijving" : {
-              "type" : "boolean"
-            },
-            "datumVan" : {
-              "type" : "boolean"
-            },
-            "datumTot" : {
-              "type" : "boolean"
-            },
-            "functieAdres" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "GeheimhoudingPersoonsgegevens" : {
-        "type" : "boolean",
-        "description" : "Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.\n"
-      },
-      "OpschortingBijhouding" : {
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/OpschortingBijhoudingBasis"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "datum" : {
-              "$ref" : "#/components/schemas/AbstractDatum"
-            }
-          },
-          "description" : "* **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.\n"
-        } ]
-      },
-      "OpschortingBijhoudingBasis" : {
-        "type" : "object",
-        "properties" : {
-          "reden" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          }
-        },
-        "description" : "* **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.\n"
-      },
-      "Partner" : {
-        "type" : "object",
-        "properties" : {
-          "burgerservicenummer" : {
-            "$ref" : "#/components/schemas/Burgerservicenummer"
-          },
-          "geslacht" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "soortVerbintenis" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "naam" : {
-            "$ref" : "#/components/schemas/NaamGerelateerde"
-          },
-          "geboorte" : {
-            "$ref" : "#/components/schemas/Geboorte"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/PartnerInOnderzoek"
-          },
-          "aangaanHuwelijkPartnerschap" : {
-            "$ref" : "#/components/schemas/AangaanHuwelijkPartnerschap"
-          },
-          "ontbindingHuwelijkPartnerschap" : {
-            "$ref" : "#/components/schemas/OntbindingHuwelijkPartnerschap"
-          }
-        }
-      },
-      "PartnerInOnderzoek" : {
-        "description" : "Geeft aan welke gegevens over het huwelijk of het partnerschap in onderzoek zijn.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "burgerservicenummer" : {
-              "type" : "boolean"
-            },
-            "geslacht" : {
-              "type" : "boolean"
-            },
-            "soortVerbintenis" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "AangaanHuwelijkPartnerschap" : {
-        "type" : "object",
-        "properties" : {
-          "datum" : {
-            "$ref" : "#/components/schemas/AbstractDatum"
-          },
-          "land" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "plaats" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/AangaanHuwelijkPartnerschapInOnderzoek"
-          }
-        },
-        "description" : "Gegevens over de voltrekking van het huwelijk of het aangaan van het geregistreerd partnerschap.\n* **datum** - De datum waarop het huwelijk is voltrokken of het partnerschap is aangegaan.\n* **land** - Het land waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.\n* **plaats** - De gemeente waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel \"Gemeenten\" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats.\n"
-      },
-      "AangaanHuwelijkPartnerschapInOnderzoek" : {
-        "description" : "Geeft aan welke gegevens over het voltrekken van het huwelijk of aangaan van het partnerschap in onderzoek zijn.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "datum" : {
-              "type" : "boolean"
-            },
-            "land" : {
-              "type" : "boolean"
-            },
-            "plaats" : {
-              "type" : "boolean"
-            }
-          }
-        } ]
-      },
-      "OntbindingHuwelijkPartnerschap" : {
-        "type" : "object",
-        "properties" : {
-          "datum" : {
-            "$ref" : "#/components/schemas/AbstractDatum"
-          },
-          "land" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "plaats" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "reden" : {
-            "$ref" : "#/components/schemas/Waardetabel"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/OntbindingHuwelijkPartnerschapInOnderzoek"
-          }
-        },
-        "description" : "Gegevens over de ontbinding van het huwelijk of het geregistreerd partnerschap.\n* **datum** : De datum waarop het huwelijk of het partnerschap is ontbonden.\n"
-      },
-      "OntbindingHuwelijkPartnerschapInOnderzoek" : {
-        "description" : "Geeft aan welke gegevens over het onbinden van het huwelijk of aangaan van het partnerschap in onderzoek zijn.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/InOnderzoek"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "datum" : {
-              "type" : "boolean"
-            },
-            "land" : {
-              "type" : "boolean"
-            },
-            "plaats" : {
-              "type" : "boolean"
-            },
-            "reden" : {
               "type" : "boolean"
             }
           }
@@ -1362,141 +861,153 @@
           }
         }
       },
-      "NaamGerelateerde" : {
+      "VerblijfadresBinnenland" : {
         "type" : "object",
         "properties" : {
-          "voornamen" : {
-            "$ref" : "#/components/schemas/Voornamen"
+          "officieleStraatnaam" : {
+            "$ref" : "#/components/schemas/OfficieleStraatnaam"
           },
-          "adellijkeTitelPredicaat" : {
-            "$ref" : "#/components/schemas/AdellijkeTitelPredicaatType"
+          "korteStraatnaam" : {
+            "$ref" : "#/components/schemas/KorteStraatnaam"
           },
-          "voorvoegsel" : {
-            "$ref" : "#/components/schemas/Voorvoegsel"
+          "huisnummer" : {
+            "$ref" : "#/components/schemas/Huisnummer"
           },
-          "geslachtsnaam" : {
-            "$ref" : "#/components/schemas/Geslachtsnaam"
+          "huisletter" : {
+            "$ref" : "#/components/schemas/Huisletter"
           },
-          "voorletters" : {
-            "$ref" : "#/components/schemas/Voorletters"
+          "huisnummertoevoeging" : {
+            "$ref" : "#/components/schemas/Huisnummertoevoeging"
+          },
+          "aanduidingBijHuisnummer" : {
+            "$ref" : "#/components/schemas/Waardetabel"
+          },
+          "postcode" : {
+            "$ref" : "#/components/schemas/Postcode"
+          },
+          "woonplaats" : {
+            "$ref" : "#/components/schemas/Woonplaats"
           },
           "inOnderzoek" : {
-            "$ref" : "#/components/schemas/NaamInOnderzoek"
+            "$ref" : "#/components/schemas/VerblijfadresBinnenlandInOnderzoek"
           }
         }
       },
-      "Voornamen" : {
-        "maxLength" : 200,
-        "pattern" : "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$",
+      "OfficieleStraatnaam" : {
+        "maxLength" : 80,
         "type" : "string",
-        "description" : "De verzameling namen voor de geslachtsnaam, gescheiden door spaties.\n"
+        "description" : "De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG).\n"
       },
-      "AdellijkeTitelPredicaatType" : {
-        "description" : "Wordt gevuld met waarden uit de landelijke tabel 'Adellijke titel/predicaat'. De property soort geeft aan of het een 'predicaat' of een 'titel' is.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/Waardetabel"
-        }, {
-          "properties" : {
-            "soort" : {
-              "$ref" : "#/components/schemas/AdellijkeTitelPredicaatSoort"
-            }
-          },
-          "example" : {
-            "value" : {
-              "code" : "JV",
-              "omschrijving" : "jonkvrouw",
-              "soort" : "predicaat"
-            }
-          }
-        } ]
-      },
-      "AdellijkeTitelPredicaatSoort" : {
+      "KorteStraatnaam" : {
+        "maxLength" : 24,
         "type" : "string",
-        "enum" : [ "titel", "predicaat" ]
+        "description" : "De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG), zo nodig verkort tot maximaal 24 tekens, of de straatnaam van een niet-BAG adres.\n"
       },
-      "Voorvoegsel" : {
-        "maxLength" : 10,
-        "pattern" : "^[a-zA-Z \\']{1,10}$",
+      "Huisnummer" : {
+        "maximum" : 99999,
+        "minimum" : 1,
+        "type" : "integer",
+        "description" : "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.\n",
+        "example" : 14
+      },
+      "Huisletter" : {
+        "pattern" : "^[a-zA-Z]{1}$",
         "type" : "string",
-        "example" : "de"
+        "description" : "Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.\n",
+        "example" : "a"
       },
-      "Geslachtsnaam" : {
-        "pattern" : "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$",
+      "Huisnummertoevoeging" : {
+        "pattern" : "^[a-zA-Z0-9 \\-]{1,4}$",
         "type" : "string",
-        "description" : "De achternaam van een persoon.\n",
-        "example" : "Vries"
+        "description" : "Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.\n",
+        "example" : "bis"
       },
-      "Voorletters" : {
-        "pattern" : "^[a-zA-Z0-9À-ž \\.]{1,40}$",
+      "Postcode" : {
+        "pattern" : "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$",
         "type" : "string",
-        "description" : "De voorletters van de persoon, afgeleid van de voornamen.\n",
-        "example" : "P.J."
+        "description" : "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.\n",
+        "example" : "2341SX"
       },
-      "NaamInOnderzoek" : {
-        "description" : "Geeft aan welke gegevens over de naam in onderzoek zijn.\n",
+      "Woonplaats" : {
+        "title" : "woonplaats naam",
+        "pattern" : "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$",
+        "type" : "string",
+        "description" : "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.\n",
+        "example" : "Duiven"
+      },
+      "VerblijfadresBinnenlandInOnderzoek" : {
         "allOf" : [ {
           "$ref" : "#/components/schemas/InOnderzoek"
         }, {
           "type" : "object",
           "properties" : {
-            "voornamen" : {
+            "aanduidingBijHuisnummer" : {
               "type" : "boolean"
             },
-            "adellijkeTitelPredicaat" : {
+            "huisletter" : {
               "type" : "boolean"
             },
-            "voorvoegsel" : {
+            "huisnummer" : {
               "type" : "boolean"
             },
-            "geslachtsnaam" : {
+            "huisnummertoevoeging" : {
               "type" : "boolean"
             },
-            "voorletters" : {
+            "officieleStraatnaam" : {
+              "type" : "boolean"
+            },
+            "postcode" : {
+              "type" : "boolean"
+            },
+            "korteStraatnaam" : {
+              "type" : "boolean"
+            },
+            "woonplaats" : {
               "type" : "boolean"
             }
           }
         } ]
       },
-      "Geboorte" : {
-        "description" : "Gegevens over de geboorte.\n* **datum** - datum waarop de persoon is geboren.\n* **land** - land waar de persoon is geboren. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.\n* **plaats** - gemeente waar de persoon is geboren. Wordt gevuld met waarden uit de landelijke tabel \"Gemeenten\" voor een gemeente in Nederland of als de persoon is geboren buiten Nederland de omschrijving van een buitenlandse plaatsnaam of aanduiding.\n",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/GeboorteBasis"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "land" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "plaats" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
-            "inOnderzoek" : {
-              "$ref" : "#/components/schemas/GeboorteInOnderzoek"
-            }
-          }
-        } ]
+      "AdresseerbaarObjectIdentificatie" : {
+        "pattern" : "^[0-9]{16}$",
+        "type" : "string",
+        "description" : "De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.\n",
+        "example" : "0226010000038820"
       },
-      "GeboorteBasis" : {
+      "NummeraanduidingIdentificatie" : {
+        "pattern" : "^[0-9]{16}$",
+        "type" : "string",
+        "description" : "Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.\n",
+        "example" : "0518200000366054"
+      },
+      "IndicatieVastgesteldVerblijftNietOpAdres" : {
+        "type" : "boolean",
+        "description" : "Geeft aan dat is vastgesteld dat de persoon niet meer op de geregistreerde adres/locatie staat ingeschreven.\n"
+      },
+      "VerblijfadresLocatie" : {
         "type" : "object",
         "properties" : {
-          "datum" : {
-            "$ref" : "#/components/schemas/AbstractDatum"
+          "locatiebeschrijving" : {
+            "$ref" : "#/components/schemas/Locatiebeschrijving"
+          },
+          "inOnderzoek" : {
+            "$ref" : "#/components/schemas/VerblijfadresLocatieInOnderzoek"
           }
         }
       },
-      "GeboorteInOnderzoek" : {
+      "Locatiebeschrijving" : {
+        "maxLength" : 35,
+        "type" : "string",
+        "description" : "Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.\n",
+        "example" : "Naast de derde brug"
+      },
+      "VerblijfadresLocatieInOnderzoek" : {
         "allOf" : [ {
           "$ref" : "#/components/schemas/InOnderzoek"
         }, {
           "type" : "object",
           "properties" : {
-            "datum" : {
-              "type" : "boolean"
-            },
-            "land" : {
-              "type" : "boolean"
-            },
-            "plaats" : {
+            "locatiebeschrijving" : {
               "type" : "boolean"
             }
           }

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -501,6 +501,9 @@
             "type" : {
               "type" : "boolean"
             },
+            "gemeenteVanInschrijving" : {
+              "type" : "boolean"
+            },
             "datumVan" : {
               "type" : "boolean"
             },

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -563,8 +563,6 @@ components:
         properties:
           type:
             type: boolean
-          gemeenteVanInschrijving:
-            type: boolean
           datumVan:
             type: boolean
           datumTot:

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -392,6 +392,8 @@ components:
         properties:
           type:
             type: boolean
+          gemeenteVanInschrijving:
+            type: boolean
           datumVan:
             type: boolean
           datumTot:

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/
-  version: 2.0.0 (develop)
+  version: 2.0.0
 servers:
 - url: https://www.haalcentraal.nl/haalcentraal/api/brphistorie
   description: APILAB testserver historie
@@ -176,164 +176,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Foutbericht'
-  /partnerhistorie:
-    post:
-      tags:
-      - BRP historie bevragen
-      description: |
-        Raadpleeg de partnerhistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.
-        De meest actuele partner staat bovenaan.
-
-        Zoek met burgerservicenummer
-      operationId: Partnerhistorie
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/HistorieQuery'
-      responses:
-        "200":
-          description: |
-            Zoekactie geslaagd
-          headers:
-            warning:
-              $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PartnerhistorieQueryResponse'
-        "400":
-          description: Bad Request
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/BadRequestFoutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
-                title: Ten minste één parameter moet worden opgegeven.
-                status: 400
-                detail: The request could not be understood by the server due to malformed
-                  syntax. The client SHOULD NOT repeat the request without modification.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: paramsRequired
-                invalidParams:
-                - type: https://www.vng.nl/realisatie/api/validaties/integer
-                  name: huisnummer
-                  code: integer
-                  reason: Waarde is geen geldig getal.
-        "401":
-          description: Unauthorized
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
-                title: Niet correct geauthenticeerd.
-                status: 401
-                detail: The request requires user authentication. The response MUST
-                  include a WWW-Authenticate header field (section 14.47) containing
-                  a challenge applicable to the requested resource.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: authentication
-        "403":
-          description: Forbidden
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
-                title: U bent niet geautoriseerd voor deze operatie.
-                status: 403
-                detail: "The server understood the request, but is refusing to fulfill\
-                  \ it."
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: autorisation
-        "406":
-          description: Not Acceptable
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
-                title: Gevraagde contenttype wordt niet ondersteund.
-                status: 406
-                detail: The resource identified by the request is only capable of
-                  generating response entities which have content characteristics
-                  not acceptable according to thr accept headers sent in the request
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: notAcceptable
-        "415":
-          description: Unsupported Media Type
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
-        "500":
-          description: Internal Server Error
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
-                title: Interne server fout.
-                status: 500
-                detail: The server encountered an unexpected condition which prevented
-                  it from fulfilling the request.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: serverError
-        "503":
-          description: Service Unavailable
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
-                title: Bronservice BRP is tijdelijk niet beschikbaar.
-                status: 503
-                detail: The service is currently unable to handle the request due
-                  to a temporary overloading or maintenance of the server.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: notAvailable
-        default:
-          description: Er is een onverwachte fout opgetreden
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
 components:
   schemas:
     HistorieQuery:
@@ -349,6 +191,8 @@ components:
           $ref: '#/components/schemas/Burgerservicenummer'
         exclusiefVerblijfplaatsBuitenland:
           type: boolean
+          description: |
+            consumers die niet zijn geautoriseerd voor verblijfplaats buitenland kunnen deze parameter gebruiken om alleen binnenlandse verblijfplaats voorkomens te vragen
       discriminator:
         propertyName: type
         mapping:
@@ -393,18 +237,7 @@ components:
         verblijfplaatsen:
           type: array
           items:
-            $ref: '#/components/schemas/AbstractVerblijfplaats'
-        geheimhoudingPersoonsgegevens:
-          $ref: '#/components/schemas/GeheimhoudingPersoonsgegevens'
-        opschortingBijhouding:
-          $ref: '#/components/schemas/OpschortingBijhouding'
-    PartnerhistorieQueryResponse:
-      type: object
-      properties:
-        partners:
-          type: array
-          items:
-            $ref: '#/components/schemas/Partner'
+            $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
         geheimhoudingPersoonsgegevens:
           $ref: '#/components/schemas/GeheimhoudingPersoonsgegevens'
         opschortingBijhouding:
@@ -478,7 +311,7 @@ components:
       pattern: "^[0-9]{9}$"
       type: string
       example: "555555021"
-    AbstractVerblijfplaats:
+    AbstractVerblijfplaatsVoorkomen:
       required:
       - type
       type: object
@@ -486,20 +319,19 @@ components:
         type:
           type: string
       description: |
-        Gegevens over het verblijf of de woonlocatie van een persoon.
+        Gegevens over het verblijfplaats voorkomen van een persoon.
       discriminator:
         propertyName: type
         mapping:
-          VerblijfplaatsBuitenland: '#/components/schemas/VerblijfplaatsBuitenland'
-          Adres: '#/components/schemas/Adres'
-          VerblijfplaatsOnbekend: '#/components/schemas/VerblijfplaatsOnbekend'
-          Locatie: '#/components/schemas/Locatie'
-    VerblijfplaatsBuitenland:
+          VerblijfplaatsBuitenland: '#/components/schemas/VerblijfplaatsBuitenlandVoorkomen'
+          Adres: '#/components/schemas/AdresVoorkomen'
+          VerblijfplaatsOnbekend: '#/components/schemas/VerblijfplaatsOnbekendVoorkomen'
+          Locatie: '#/components/schemas/LocatieVoorkomen'
+    VerblijfplaatsBuitenlandVoorkomen:
       description: |
-        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
         * **land** - land waar de persoon is overleden. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
       allOf:
-      - $ref: '#/components/schemas/AbstractVerblijfplaats'
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
       - type: object
         properties:
           verblijfadres:
@@ -509,9 +341,148 @@ components:
           datumTot:
             $ref: '#/components/schemas/AbstractDatum'
           inOnderzoek:
-            $ref: '#/components/schemas/VerblijfplaatsBuitenlandInOnderzoek'
+            $ref: '#/components/schemas/VerblijfplaatsBuitenlandVoorkomenInOnderzoek'
           rni:
             $ref: '#/components/schemas/RniDeelnemer'
+    VerblijfplaatsBuitenlandVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+    AdresVoorkomen:
+      description: |
+        Gegevens over het adres voorkomen van een persoon.
+        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
+        * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
+        * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
+        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          verblijfadres:
+            $ref: '#/components/schemas/VerblijfadresBinnenland'
+          functieAdres:
+            $ref: '#/components/schemas/Waardetabel'
+          adresseerbaarObjectIdentificatie:
+            $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
+          nummeraanduidingIdentificatie:
+            $ref: '#/components/schemas/NummeraanduidingIdentificatie'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          indicatieVastgesteldVerblijftNietOpAdres:
+            $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
+          inOnderzoek:
+            $ref: '#/components/schemas/AdresVoorkomenInOnderzoek'
+    AdresVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+          nummeraanduidingIdentificatie:
+            type: boolean
+          adresseerbaarObjectIdentificatie:
+            type: boolean
+          functieAdres:
+            type: boolean
+    VerblijfplaatsOnbekendVoorkomen:
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          inOnderzoek:
+            $ref: '#/components/schemas/VerblijfplaatsOnbekendVoorkomenInOnderzoek'
+          rni:
+            $ref: '#/components/schemas/RniDeelnemer'
+    VerblijfplaatsOnbekendVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+    LocatieVoorkomen:
+      description: |
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
+        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          functieAdres:
+            $ref: '#/components/schemas/Waardetabel'
+          verblijfadres:
+            $ref: '#/components/schemas/VerblijfadresLocatie'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          indicatieVastgesteldVerblijftNietOpAdres:
+            $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
+          inOnderzoek:
+            $ref: '#/components/schemas/LocatieVoorkomenInOnderzoek'
+    LocatieVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          gemeenteVanInschrijving:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+          functieAdres:
+            type: boolean
+    GeheimhoudingPersoonsgegevens:
+      type: boolean
+      description: |
+        Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
+    OpschortingBijhouding:
+      allOf:
+      - $ref: '#/components/schemas/OpschortingBijhoudingBasis'
+      - type: object
+        properties:
+          datum:
+            $ref: '#/components/schemas/AbstractDatum'
+        description: |
+          * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
+    OpschortingBijhoudingBasis:
+      type: object
+      properties:
+        reden:
+          $ref: '#/components/schemas/Waardetabel'
+      description: |
+        * **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.
     VerblijfadresBuitenland:
       type: object
       properties:
@@ -555,360 +526,6 @@ components:
           regel3:
             type: boolean
           land:
-            type: boolean
-    VerblijfplaatsBuitenlandInOnderzoek:
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          type:
-            type: boolean
-          datumVan:
-            type: boolean
-          datumTot:
-            type: boolean
-    Adres:
-      description: |
-        Gegevens over het adres van een persoon.
-        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
-        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
-        * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
-        * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
-        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
-      allOf:
-      - $ref: '#/components/schemas/AbstractVerblijfplaats'
-      - type: object
-        properties:
-          verblijfadres:
-            $ref: '#/components/schemas/VerblijfadresBinnenland'
-          functieAdres:
-            $ref: '#/components/schemas/Waardetabel'
-          adresseerbaarObjectIdentificatie:
-            $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
-          nummeraanduidingIdentificatie:
-            $ref: '#/components/schemas/NummeraanduidingIdentificatie'
-          gemeenteVanInschrijving:
-            $ref: '#/components/schemas/Waardetabel'
-          datumVan:
-            $ref: '#/components/schemas/AbstractDatum'
-          datumTot:
-            $ref: '#/components/schemas/AbstractDatum'
-          indicatieVastgesteldVerblijftNietOpAdres:
-            $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
-          inOnderzoek:
-            $ref: '#/components/schemas/AdresInOnderzoek'
-    VerblijfadresBinnenland:
-      type: object
-      properties:
-        officieleStraatnaam:
-          $ref: '#/components/schemas/OfficieleStraatnaam'
-        korteStraatnaam:
-          $ref: '#/components/schemas/KorteStraatnaam'
-        huisnummer:
-          $ref: '#/components/schemas/Huisnummer'
-        huisletter:
-          $ref: '#/components/schemas/Huisletter'
-        huisnummertoevoeging:
-          $ref: '#/components/schemas/Huisnummertoevoeging'
-        aanduidingBijHuisnummer:
-          $ref: '#/components/schemas/Waardetabel'
-        postcode:
-          $ref: '#/components/schemas/Postcode'
-        woonplaats:
-          $ref: '#/components/schemas/Woonplaats'
-        inOnderzoek:
-          $ref: '#/components/schemas/VerblijfadresBinnenlandInOnderzoek'
-    OfficieleStraatnaam:
-      maxLength: 80
-      type: string
-      description: |
-        De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG).
-    KorteStraatnaam:
-      maxLength: 24
-      type: string
-      description: |
-        De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG), zo nodig verkort tot maximaal 24 tekens, of de straatnaam van een niet-BAG adres.
-    Huisnummer:
-      maximum: 99999
-      minimum: 1
-      type: integer
-      description: |
-        Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
-      example: 14
-    Huisletter:
-      pattern: "^[a-zA-Z]{1}$"
-      type: string
-      description: |
-        Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
-      example: a
-    Huisnummertoevoeging:
-      pattern: "^[a-zA-Z0-9 \\-]{1,4}$"
-      type: string
-      description: |
-        Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
-      example: bis
-    Postcode:
-      pattern: "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$"
-      type: string
-      description: |
-        De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
-      example: 2341SX
-    Woonplaats:
-      title: woonplaats naam
-      pattern: "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$"
-      type: string
-      description: |
-        Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.
-      example: Duiven
-    VerblijfadresBinnenlandInOnderzoek:
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          aanduidingBijHuisnummer:
-            type: boolean
-          huisletter:
-            type: boolean
-          huisnummer:
-            type: boolean
-          huisnummertoevoeging:
-            type: boolean
-          officieleStraatnaam:
-            type: boolean
-          postcode:
-            type: boolean
-          korteStraatnaam:
-            type: boolean
-          woonplaats:
-            type: boolean
-    AdresseerbaarObjectIdentificatie:
-      pattern: "^[0-9]{16}$"
-      type: string
-      description: |
-        De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
-      example: "0226010000038820"
-    NummeraanduidingIdentificatie:
-      pattern: "^[0-9]{16}$"
-      type: string
-      description: |
-        Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
-      example: "0518200000366054"
-    IndicatieVastgesteldVerblijftNietOpAdres:
-      type: boolean
-      description: |
-        Geeft aan dat is vastgesteld dat de persoon niet meer op de geregistreerde adres/locatie staat ingeschreven.
-    AdresInOnderzoek:
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          type:
-            type: boolean
-          gemeenteVanInschrijving:
-            type: boolean
-          datumVan:
-            type: boolean
-          datumTot:
-            type: boolean
-          nummeraanduidingIdentificatie:
-            type: boolean
-          adresseerbaarObjectIdentificatie:
-            type: boolean
-          functieAdres:
-            type: boolean
-    VerblijfplaatsOnbekend:
-      allOf:
-      - $ref: '#/components/schemas/AbstractVerblijfplaats'
-      - type: object
-        properties:
-          datumVan:
-            $ref: '#/components/schemas/AbstractDatum'
-          datumTot:
-            $ref: '#/components/schemas/AbstractDatum'
-          inOnderzoek:
-            $ref: '#/components/schemas/VerblijfplaatsOnbekendInOnderzoek'
-          rni:
-            $ref: '#/components/schemas/RniDeelnemer'
-    VerblijfplaatsOnbekendInOnderzoek:
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          type:
-            type: boolean
-          datumVan:
-            type: boolean
-          datumTot:
-            type: boolean
-    Locatie:
-      description: |
-        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
-        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
-        * **landVanWaarIngeschreven** : het land waar de persoon woonde voor (her)vestiging in Nederland. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
-      allOf:
-      - $ref: '#/components/schemas/AbstractVerblijfplaats'
-      - type: object
-        properties:
-          datumVan:
-            $ref: '#/components/schemas/AbstractDatum'
-          datumTot:
-            $ref: '#/components/schemas/AbstractDatum'
-          functieAdres:
-            $ref: '#/components/schemas/Waardetabel'
-          verblijfadres:
-            $ref: '#/components/schemas/VerblijfadresLocatie'
-          gemeenteVanInschrijving:
-            $ref: '#/components/schemas/Waardetabel'
-          indicatieVastgesteldVerblijftNietOpAdres:
-            $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
-          inOnderzoek:
-            $ref: '#/components/schemas/LocatieInOnderzoek'
-    VerblijfadresLocatie:
-      type: object
-      properties:
-        locatiebeschrijving:
-          $ref: '#/components/schemas/Locatiebeschrijving'
-        inOnderzoek:
-          $ref: '#/components/schemas/VerblijfadresLocatieInOnderzoek'
-    Locatiebeschrijving:
-      maxLength: 35
-      type: string
-      description: |
-        Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.
-      example: Naast de derde brug
-    VerblijfadresLocatieInOnderzoek:
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          locatiebeschrijving:
-            type: boolean
-    LocatieInOnderzoek:
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          type:
-            type: boolean
-          gemeenteVanInschrijving:
-            type: boolean
-          datumVan:
-            type: boolean
-          datumTot:
-            type: boolean
-          functieAdres:
-            type: boolean
-    GeheimhoudingPersoonsgegevens:
-      type: boolean
-      description: |
-        Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
-    OpschortingBijhouding:
-      allOf:
-      - $ref: '#/components/schemas/OpschortingBijhoudingBasis'
-      - type: object
-        properties:
-          datum:
-            $ref: '#/components/schemas/AbstractDatum'
-        description: |
-          * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
-    OpschortingBijhoudingBasis:
-      type: object
-      properties:
-        reden:
-          $ref: '#/components/schemas/Waardetabel'
-      description: |
-        * **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.
-    Partner:
-      type: object
-      properties:
-        burgerservicenummer:
-          $ref: '#/components/schemas/Burgerservicenummer'
-        geslacht:
-          $ref: '#/components/schemas/Waardetabel'
-        soortVerbintenis:
-          $ref: '#/components/schemas/Waardetabel'
-        naam:
-          $ref: '#/components/schemas/NaamGerelateerde'
-        geboorte:
-          $ref: '#/components/schemas/Geboorte'
-        inOnderzoek:
-          $ref: '#/components/schemas/PartnerInOnderzoek'
-        aangaanHuwelijkPartnerschap:
-          $ref: '#/components/schemas/AangaanHuwelijkPartnerschap'
-        ontbindingHuwelijkPartnerschap:
-          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschap'
-    PartnerInOnderzoek:
-      description: |
-        Geeft aan welke gegevens over het huwelijk of het partnerschap in onderzoek zijn.
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          burgerservicenummer:
-            type: boolean
-          geslacht:
-            type: boolean
-          soortVerbintenis:
-            type: boolean
-    AangaanHuwelijkPartnerschap:
-      type: object
-      properties:
-        datum:
-          $ref: '#/components/schemas/AbstractDatum'
-        land:
-          $ref: '#/components/schemas/Waardetabel'
-        plaats:
-          $ref: '#/components/schemas/Waardetabel'
-        inOnderzoek:
-          $ref: '#/components/schemas/AangaanHuwelijkPartnerschapInOnderzoek'
-      description: |
-        Gegevens over de voltrekking van het huwelijk of het aangaan van het geregistreerd partnerschap.
-        * **datum** - De datum waarop het huwelijk is voltrokken of het partnerschap is aangegaan.
-        * **land** - Het land waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
-        * **plaats** - De gemeente waar het huwelijk is voltrokken of het partnerschap is aangegaan. Wordt gevuld met waarden uit de landelijke tabel "Gemeenten" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats.
-    AangaanHuwelijkPartnerschapInOnderzoek:
-      description: |
-        Geeft aan welke gegevens over het voltrekken van het huwelijk of aangaan van het partnerschap in onderzoek zijn.
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          datum:
-            type: boolean
-          land:
-            type: boolean
-          plaats:
-            type: boolean
-    OntbindingHuwelijkPartnerschap:
-      type: object
-      properties:
-        datum:
-          $ref: '#/components/schemas/AbstractDatum'
-        land:
-          $ref: '#/components/schemas/Waardetabel'
-        plaats:
-          $ref: '#/components/schemas/Waardetabel'
-        reden:
-          $ref: '#/components/schemas/Waardetabel'
-        inOnderzoek:
-          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschapInOnderzoek'
-      description: |
-        Gegevens over de ontbinding van het huwelijk of het geregistreerd partnerschap.
-        * **datum** : De datum waarop het huwelijk of het partnerschap is ontbonden.
-    OntbindingHuwelijkPartnerschapInOnderzoek:
-      description: |
-        Geeft aan welke gegevens over het onbinden van het huwelijk of aangaan van het partnerschap in onderzoek zijn.
-      allOf:
-      - $ref: '#/components/schemas/InOnderzoek'
-      - type: object
-        properties:
-          datum:
-            type: boolean
-          land:
-            type: boolean
-          plaats:
-            type: boolean
-          reden:
             type: boolean
     AbstractDatum:
       required:
@@ -1032,110 +649,125 @@ components:
       properties:
         datumIngangOnderzoek:
           $ref: '#/components/schemas/AbstractDatum'
-    NaamGerelateerde:
+    VerblijfadresBinnenland:
       type: object
       properties:
-        voornamen:
-          $ref: '#/components/schemas/Voornamen'
-        adellijkeTitelPredicaat:
-          $ref: '#/components/schemas/AdellijkeTitelPredicaatType'
-        voorvoegsel:
-          $ref: '#/components/schemas/Voorvoegsel'
-        geslachtsnaam:
-          $ref: '#/components/schemas/Geslachtsnaam'
-        voorletters:
-          $ref: '#/components/schemas/Voorletters'
+        officieleStraatnaam:
+          $ref: '#/components/schemas/OfficieleStraatnaam'
+        korteStraatnaam:
+          $ref: '#/components/schemas/KorteStraatnaam'
+        huisnummer:
+          $ref: '#/components/schemas/Huisnummer'
+        huisletter:
+          $ref: '#/components/schemas/Huisletter'
+        huisnummertoevoeging:
+          $ref: '#/components/schemas/Huisnummertoevoeging'
+        aanduidingBijHuisnummer:
+          $ref: '#/components/schemas/Waardetabel'
+        postcode:
+          $ref: '#/components/schemas/Postcode'
+        woonplaats:
+          $ref: '#/components/schemas/Woonplaats'
         inOnderzoek:
-          $ref: '#/components/schemas/NaamInOnderzoek'
-    Voornamen:
-      maxLength: 200
-      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
+          $ref: '#/components/schemas/VerblijfadresBinnenlandInOnderzoek'
+    OfficieleStraatnaam:
+      maxLength: 80
       type: string
       description: |
-        De verzameling namen voor de geslachtsnaam, gescheiden door spaties.
-    AdellijkeTitelPredicaatType:
-      description: |
-        Wordt gevuld met waarden uit de landelijke tabel 'Adellijke titel/predicaat'. De property soort geeft aan of het een 'predicaat' of een 'titel' is.
-      allOf:
-      - $ref: '#/components/schemas/Waardetabel'
-      - properties:
-          soort:
-            $ref: '#/components/schemas/AdellijkeTitelPredicaatSoort'
-        example:
-          value:
-            code: JV
-            omschrijving: jonkvrouw
-            soort: predicaat
-    AdellijkeTitelPredicaatSoort:
-      type: string
-      enum:
-      - titel
-      - predicaat
-    Voorvoegsel:
-      maxLength: 10
-      pattern: "^[a-zA-Z \\']{1,10}$"
-      type: string
-      example: de
-    Geslachtsnaam:
-      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
+        De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG).
+    KorteStraatnaam:
+      maxLength: 24
       type: string
       description: |
-        De achternaam van een persoon.
-      example: Vries
-    Voorletters:
-      pattern: "^[a-zA-Z0-9À-ž \\.]{1,40}$"
+        De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG), zo nodig verkort tot maximaal 24 tekens, of de straatnaam van een niet-BAG adres.
+    Huisnummer:
+      maximum: 99999
+      minimum: 1
+      type: integer
+      description: |
+        Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
+      example: 14
+    Huisletter:
+      pattern: "^[a-zA-Z]{1}$"
       type: string
       description: |
-        De voorletters van de persoon, afgeleid van de voornamen.
-      example: P.J.
-    NaamInOnderzoek:
+        Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
+      example: a
+    Huisnummertoevoeging:
+      pattern: "^[a-zA-Z0-9 \\-]{1,4}$"
+      type: string
       description: |
-        Geeft aan welke gegevens over de naam in onderzoek zijn.
+        Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
+      example: bis
+    Postcode:
+      pattern: "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$"
+      type: string
+      description: |
+        De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
+      example: 2341SX
+    Woonplaats:
+      title: woonplaats naam
+      pattern: "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$"
+      type: string
+      description: |
+        Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.
+      example: Duiven
+    VerblijfadresBinnenlandInOnderzoek:
       allOf:
       - $ref: '#/components/schemas/InOnderzoek'
       - type: object
         properties:
-          voornamen:
+          aanduidingBijHuisnummer:
             type: boolean
-          adellijkeTitelPredicaat:
+          huisletter:
             type: boolean
-          voorvoegsel:
+          huisnummer:
             type: boolean
-          geslachtsnaam:
+          huisnummertoevoeging:
             type: boolean
-          voorletters:
+          officieleStraatnaam:
             type: boolean
-    Geboorte:
+          postcode:
+            type: boolean
+          korteStraatnaam:
+            type: boolean
+          woonplaats:
+            type: boolean
+    AdresseerbaarObjectIdentificatie:
+      pattern: "^[0-9]{16}$"
+      type: string
       description: |
-        Gegevens over de geboorte.
-        * **datum** - datum waarop de persoon is geboren.
-        * **land** - land waar de persoon is geboren. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
-        * **plaats** - gemeente waar de persoon is geboren. Wordt gevuld met waarden uit de landelijke tabel "Gemeenten" voor een gemeente in Nederland of als de persoon is geboren buiten Nederland de omschrijving van een buitenlandse plaatsnaam of aanduiding.
-      allOf:
-      - $ref: '#/components/schemas/GeboorteBasis'
-      - type: object
-        properties:
-          land:
-            $ref: '#/components/schemas/Waardetabel'
-          plaats:
-            $ref: '#/components/schemas/Waardetabel'
-          inOnderzoek:
-            $ref: '#/components/schemas/GeboorteInOnderzoek'
-    GeboorteBasis:
+        De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
+      example: "0226010000038820"
+    NummeraanduidingIdentificatie:
+      pattern: "^[0-9]{16}$"
+      type: string
+      description: |
+        Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
+      example: "0518200000366054"
+    IndicatieVastgesteldVerblijftNietOpAdres:
+      type: boolean
+      description: |
+        Geeft aan dat is vastgesteld dat de persoon niet meer op de geregistreerde adres/locatie staat ingeschreven.
+    VerblijfadresLocatie:
       type: object
       properties:
-        datum:
-          $ref: '#/components/schemas/AbstractDatum'
-    GeboorteInOnderzoek:
+        locatiebeschrijving:
+          $ref: '#/components/schemas/Locatiebeschrijving'
+        inOnderzoek:
+          $ref: '#/components/schemas/VerblijfadresLocatieInOnderzoek'
+    Locatiebeschrijving:
+      maxLength: 35
+      type: string
+      description: |
+        Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.
+      example: Naast de derde brug
+    VerblijfadresLocatieInOnderzoek:
       allOf:
       - $ref: '#/components/schemas/InOnderzoek'
       - type: object
         properties:
-          datum:
-            type: boolean
-          land:
-            type: boolean
-          plaats:
+          locatiebeschrijving:
             type: boolean
   responses:
     "400":

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -8,7 +8,7 @@ info:
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen
   license:
-    name: European Union Public License, version 1.2 (EUPL-1.2)
+    name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/
   version: 2.0.0 (develop)
 servers:
@@ -94,8 +94,8 @@ paths:
                 type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
                 title: U bent niet geautoriseerd voor deze operatie.
                 status: 403
-                detail: The server understood the request, but is refusing to fulfill
-                  it.
+                detail: "The server understood the request, but is refusing to fulfill\
+                  \ it."
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
         "406":
@@ -252,8 +252,8 @@ paths:
                 type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
                 title: U bent niet geautoriseerd voor deze operatie.
                 status: 403
-                detail: The server understood the request, but is refusing to fulfill
-                  it.
+                detail: "The server understood the request, but is refusing to fulfill\
+                  \ it."
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
         "406":
@@ -347,17 +347,8 @@ components:
           type: string
         burgerservicenummer:
           $ref: '#/components/schemas/Burgerservicenummer'
-        fields:
-          maxItems: 130
-          minItems: 1
-          type: array
-          description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen
-            ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields.feature)).
-            De te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields-Verblijfplaatshistorie.csv)
-            waarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.
-          items:
-            $ref: '#/components/schemas/Field'
+        exclusiefVerblijfplaatsBuitenland:
+          type: boolean
       discriminator:
         propertyName: type
         mapping:
@@ -437,7 +428,7 @@ components:
           description: Link naar meer informatie over deze fout
           format: uri
         title:
-          pattern: ^[a-zA-Z0-9À-ž \.\-]{1,80}$
+          pattern: "^[a-zA-Z0-9À-ž \\.\\-]{1,80}$"
           type: string
           description: Beschrijving van de fout
         status:
@@ -446,7 +437,7 @@ components:
           type: integer
           description: Http status code
         detail:
-          pattern: ^[a-zA-Z0-9À-ž \.\-\(\)\,]{1,200}$
+          pattern: "^[a-zA-Z0-9À-ž \\.\\-\\(\\)\\,]{1,200}$"
           type: string
           description: Details over de fout
         instance:
@@ -455,43 +446,38 @@ components:
           format: uri
         code:
           minLength: 1
-          pattern: ^[a-zA-Z0-9]{1,25}$
+          pattern: "^[a-zA-Z0-9]{1,25}$"
           type: string
           description: Systeemcode die het type fout aangeeft
-      description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
+      description: "Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807)."
     InvalidParams:
       type: object
       properties:
         type:
           type: string
           format: uri
-          example: https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer
+          example: "https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer"
         name:
-          pattern: ^[a-zA-Z0-9\.,_]{1,30}$
+          pattern: "^[a-zA-Z0-9\\.,_]{1,30}$"
           type: string
           description: Naam van de parameter
           example: huisnummer
         code:
           minLength: 1
-          pattern: ^[a-zA-Z0-9\.,_]{1,25}$
+          pattern: "^[a-zA-Z0-9\\.,_]{1,25}$"
           type: string
           description: Systeemcode die het type fout aangeeft
           example: integer
         reason:
-          pattern: ^[a-zA-Z0-9\.,_ ]{1,80}$
+          pattern: "^[a-zA-Z0-9\\.,_ ]{1,80}$"
           type: string
           description: Beschrijving van de fout op de parameterwaarde
           example: Waarde is geen geldig getal.
       description: Details over fouten in opgegeven parameters
     Burgerservicenummer:
-      pattern: ^[0-9]{9}$
+      pattern: "^[0-9]{9}$"
       type: string
       example: "555555021"
-    Field:
-      pattern: ^[a-zA-Z0-9\._]{1,200}$
-      type: string
-      description: |
-        Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld "burgerservicenummer", "geboorte.datum", "partners.naam.voornamen".
     AbstractVerblijfplaats:
       required:
       - type
@@ -518,8 +504,6 @@ components:
         properties:
           verblijfadres:
             $ref: '#/components/schemas/VerblijfadresBuitenland'
-          gemeenteVanInschrijving:
-            $ref: '#/components/schemas/Waardetabel'
           datumVan:
             $ref: '#/components/schemas/AbstractDatum'
           datumTot:
@@ -552,7 +536,7 @@ components:
       type: string
       description: |
         Het tweede deel van een buitenlands adres. Vaak is dit een combinatie van woonplaats eventueel in combinatie met de postcode.
-      example: Washington, DC 20500
+      example: "Washington, DC 20500"
     Regel3:
       maxLength: 35
       type: string
@@ -583,6 +567,8 @@ components:
             type: boolean
           datumVan:
             type: boolean
+          datumTot:
+            type: boolean
     Adres:
       description: |
         Gegevens over het adres van een persoon.
@@ -590,6 +576,7 @@ components:
         * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
         * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
         * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
+        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
       allOf:
       - $ref: '#/components/schemas/AbstractVerblijfplaats'
       - type: object
@@ -612,8 +599,6 @@ components:
             $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
           inOnderzoek:
             $ref: '#/components/schemas/AdresInOnderzoek'
-          rni:
-            $ref: '#/components/schemas/RniDeelnemer'
     VerblijfadresBinnenland:
       type: object
       properties:
@@ -653,26 +638,26 @@ components:
         Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
       example: 14
     Huisletter:
-      pattern: ^[a-zA-Z]{1}$
+      pattern: "^[a-zA-Z]{1}$"
       type: string
       description: |
         Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
       example: a
     Huisnummertoevoeging:
-      pattern: ^[a-zA-Z0-9 \-]{1,4}$
+      pattern: "^[a-zA-Z0-9 \\-]{1,4}$"
       type: string
       description: |
         Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
       example: bis
     Postcode:
-      pattern: ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$
+      pattern: "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$"
       type: string
       description: |
         De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
       example: 2341SX
     Woonplaats:
       title: woonplaats naam
-      pattern: ^[a-zA-Z0-9À-ž \(\)\,\.\-\']{1,80}$
+      pattern: "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$"
       type: string
       description: |
         Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.
@@ -699,13 +684,13 @@ components:
           woonplaats:
             type: boolean
     AdresseerbaarObjectIdentificatie:
-      pattern: ^[0-9]{16}$
+      pattern: "^[0-9]{16}$"
       type: string
       description: |
         De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
       example: "0226010000038820"
     NummeraanduidingIdentificatie:
-      pattern: ^[0-9]{16}$
+      pattern: "^[0-9]{16}$"
       type: string
       description: |
         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
@@ -724,6 +709,8 @@ components:
           gemeenteVanInschrijving:
             type: boolean
           datumVan:
+            type: boolean
+          datumTot:
             type: boolean
           nummeraanduidingIdentificatie:
             type: boolean
@@ -753,6 +740,8 @@ components:
             type: boolean
           datumVan:
             type: boolean
+          datumTot:
+            type: boolean
     Locatie:
       description: |
         * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
@@ -776,8 +765,6 @@ components:
             $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
           inOnderzoek:
             $ref: '#/components/schemas/LocatieInOnderzoek'
-          rni:
-            $ref: '#/components/schemas/RniDeelnemer'
     VerblijfadresLocatie:
       type: object
       properties:
@@ -808,6 +795,8 @@ components:
           gemeenteVanInschrijving:
             type: boolean
           datumVan:
+            type: boolean
+          datumTot:
             type: boolean
           functieAdres:
             type: boolean
@@ -923,17 +912,6 @@ components:
             type: boolean
           reden:
             type: boolean
-    Waardetabel:
-      type: object
-      properties:
-        code:
-          pattern: ^[a-zA-Z0-9 \.]+$
-          type: string
-          example: "6030"
-        omschrijving:
-          pattern: ^[a-zA-Z0-9À-ž \'\,\(\)\.\-]{1,200}$
-          type: string
-          example: Nederland
     AbstractDatum:
       required:
       - langFormaat
@@ -943,7 +921,7 @@ components:
         type:
           type: string
         langFormaat:
-          pattern: ^[a-z0-9 ]{1,17}$
+          pattern: "^[a-z0-9 ]{1,17}$"
           type: string
       discriminator:
         propertyName: type
@@ -1035,8 +1013,19 @@ components:
           $ref: '#/components/schemas/Waardetabel'
         omschrijvingVerdrag:
           $ref: '#/components/schemas/OmschrijvingVerdrag'
+    Waardetabel:
+      type: object
+      properties:
+        code:
+          pattern: "^[a-zA-Z0-9 \\.]+$"
+          type: string
+          example: "6030"
+        omschrijving:
+          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
+          type: string
+          example: Nederland
     OmschrijvingVerdrag:
-      pattern: ^[a-zA-Z0-9À-ž \.\-\']{1,50}$
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,50}$"
       type: string
       description: |
         Omschrijving van het verdrag op basis waarvan een zusterorganisatie in het buitenland de gegevens bij de RNI-deelnemer heeft aangeleverd.
@@ -1062,7 +1051,7 @@ components:
           $ref: '#/components/schemas/NaamInOnderzoek'
     Voornamen:
       maxLength: 200
-      pattern: ^[a-zA-Z0-9À-ž \.\-\']{1,200}$
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
       type: string
       description: |
         De verzameling namen voor de geslachtsnaam, gescheiden door spaties.
@@ -1086,17 +1075,17 @@ components:
       - predicaat
     Voorvoegsel:
       maxLength: 10
-      pattern: ^[a-zA-Z \']{1,10}$
+      pattern: "^[a-zA-Z \\']{1,10}$"
       type: string
       example: de
     Geslachtsnaam:
-      pattern: ^[a-zA-Z0-9À-ž \.\-\']{1,200}$
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,200}$"
       type: string
       description: |
         De achternaam van een persoon.
       example: Vries
     Voorletters:
-      pattern: ^[a-zA-Z0-9À-ž \.]{1,40}$
+      pattern: "^[a-zA-Z0-9À-ž \\.]{1,40}$"
       type: string
       description: |
         De voorletters van de persoon, afgeleid van de voornamen.
@@ -1150,18 +1139,145 @@ components:
             type: boolean
           plaats:
             type: boolean
+  responses:
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestFoutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+            title: Ten minste één parameter moet worden opgegeven.
+            status: 400
+            detail: The request could not be understood by the server due to malformed
+              syntax. The client SHOULD NOT repeat the request without modification.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: paramsRequired
+            invalidParams:
+            - type: https://www.vng.nl/realisatie/api/validaties/integer
+              name: huisnummer
+              code: integer
+              reason: Waarde is geen geldig getal.
+    "401":
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+            title: Niet correct geauthenticeerd.
+            status: 401
+            detail: The request requires user authentication. The response MUST include
+              a WWW-Authenticate header field (section 14.47) containing a challenge
+              applicable to the requested resource.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: authentication
+    "403":
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+            title: U bent niet geautoriseerd voor deze operatie.
+            status: 403
+            detail: "The server understood the request, but is refusing to fulfill\
+              \ it."
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: autorisation
+    "406":
+      description: Not Acceptable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+            title: Gevraagde contenttype wordt niet ondersteund.
+            status: 406
+            detail: The resource identified by the request is only capable of generating
+              response entities which have content characteristics not acceptable
+              according to thr accept headers sent in the request
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAcceptable
+    "415":
+      description: Unsupported Media Type
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
+            title: Unsupported Media Type
+            status: 415
+            detail: The server is refusing the request because the entity of the request
+              is in a format not supported by the requested resource for the requested
+              method.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: unsupported
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+            title: Too many request
+            status: 429
+            detail: The user has sent too many requests in a given amount of time
+              (rate limiting).
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: tooManyRequests
+    "500":
+      description: Internal Server Error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+            title: Interne server fout.
+            status: 500
+            detail: The server encountered an unexpected condition which prevented
+              it from fulfilling the request.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: serverError
+    "503":
+      description: Service Unavailable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+            title: Bronservice BRP is tijdelijk niet beschikbaar.
+            status: 503
+            detail: The service is currently unable to handle the request due to a
+              temporary overloading or maintenance of the server.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAvailable
+    default:
+      description: Er is een onverwachte fout opgetreden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
   headers:
     warning:
       schema:
         maxLength: 500
         type: string
-        description: zie RFC 7234. In het geval een major versie wordt uitgefaseerd,
-          gebruiken we warn-code 299 ("Miscellaneous Persistent Warning") en het API
-          end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd
-          door de warn-text met de human-readable waarschuwing
-        example: '299 https://service.../api/.../v1 "Deze versie van de API is verouderd
-          en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
-          hier de documentatie: https://omgevingswet.../api/.../v1".'
+        description: "zie RFC 7234. In het geval een major versie wordt uitgefaseerd,\
+          \ gebruiken we warn-code 299 (\"Miscellaneous Persistent Warning\") en het\
+          \ API end-point (inclusief versienummer) als de warn-agent van de warning,\
+          \ gevolgd door de warn-text met de human-readable waarschuwing"
+        example: "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd\
+          \ en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie\
+          \ hier de documentatie: https://omgevingswet.../api/.../v1\"."
     X_Rate_Limit_Limit:
       schema:
         type: integer

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -92,6 +92,8 @@ components:
           $ref: "persoon.yaml#/components/schemas/Burgerservicenummer"
         exclusiefVerblijfplaatsBuitenland:
           type: boolean
+          description: |
+            consumers die niet zijn geautoriseerd voor verblijfplaats buitenland kunnen deze parameter gebruiken om alleen binnenlandse verblijfplaats voorkomens te vragen
     RaadpleegMetPeildatum:
       required:
         - peildatum
@@ -131,18 +133,7 @@ components:
         verblijfplaatsen:
           type: array
           items:
-            $ref: 'verblijfplaats.yaml#/components/schemas/AbstractVerblijfplaats'
-        geheimhoudingPersoonsgegevens:
-          $ref: 'persoon.yaml#/components/schemas/GeheimhoudingPersoonsgegevens'
-        opschortingBijhouding:
-          $ref: 'opschortingbijhouding.yaml#/components/schemas/OpschortingBijhouding'
-    PartnerhistorieQueryResponse:
-      type: object
-      properties:
-        partners:
-          type: array
-          items:
-            $ref: 'partner.yaml#/components/schemas/Partner'
+            $ref: 'verblijfplaats-voorkomen.yaml#/components/schemas/AbstractVerblijfplaatsVoorkomen'
         geheimhoudingPersoonsgegevens:
           $ref: 'persoon.yaml#/components/schemas/GeheimhoudingPersoonsgegevens'
         opschortingBijhouding:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -140,17 +140,8 @@ components:
           type: string
         burgerservicenummer:
           $ref: "persoon.yaml#/components/schemas/Burgerservicenummer"
-        fields:
-          description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen
-            ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields.feature)).
-            De te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/develop/features/fields-Verblijfplaatshistorie.csv)
-            waarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.
-          type: array
-          maxItems: 130
-          minItems: 1
-          items:
-            $ref: 'filter.yaml#/components/schemas/Field'
+        exclusiefVerblijfplaatsBuitenland:
+          type: boolean
     RaadpleegMetPeildatum:
       required:
         - peildatum

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -8,7 +8,7 @@ info:
                 API voor het zoeken en raadplegen van historische verblijfplaatsen, partners, nationaliteiten en verblijfstitels uit de BRP (inclusief de RNI).
 
                 Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/tree/v1.0.0/features) voor nadere toelichting.
-  version: 2.0.0 (develop)
+  version: 2.0.0
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen
   license:
@@ -48,56 +48,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/VerblijfplaatshistorieQueryResponse"
-        '400':
-          $ref: "common.yaml#/components/responses/400"
-        '401':
-          $ref: "common.yaml#/components/responses/401"
-        '403':
-          $ref: "common.yaml#/components/responses/403"
-        '406':
-          $ref: "common.yaml#/components/responses/406"
-        '415':
-          $ref: 'common.yaml#/components/responses/415'
-        '429':
-          $ref: "common.yaml#/components/responses/429"
-        '500':
-          $ref: "common.yaml#/components/responses/500"
-        '503':
-          $ref: "common.yaml#/components/responses/503"
-        'default':
-          $ref: "common.yaml#/components/responses/default"
-      tags:
-        - BRP historie bevragen
-  /partnerhistorie:
-    post:
-      description: |
-        Raadpleeg de partnerhistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.
-        De meest actuele partner staat bovenaan.
-
-        Zoek met burgerservicenummer
-      operationId: Partnerhistorie
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/HistorieQuery"
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            warning:
-              $ref: "common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Reset"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PartnerhistorieQueryResponse'
         '400':
           $ref: "common.yaml#/components/responses/400"
         '401':

--- a/specificatie/verblijfplaats-voorkomen.yaml
+++ b/specificatie/verblijfplaats-voorkomen.yaml
@@ -149,6 +149,8 @@ components:
           properties:
             type:
               type: boolean
+            gemeenteVanInschrijving:
+              type: boolean
             datumVan:
               type: boolean
             datumTot:

--- a/specificatie/verblijfplaats-voorkomen.yaml
+++ b/specificatie/verblijfplaats-voorkomen.yaml
@@ -1,0 +1,187 @@
+openapi: 3.0.3
+info:
+  title: VerblijfplaatsVoorkomen definities
+  version: 2.0.0
+  contact: {}
+paths: {}
+components:
+  schemas:
+    AbstractVerblijfplaatsVoorkomen:
+      type: object
+      description: |
+        Gegevens over het verblijfplaats voorkomen van een persoon.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          VerblijfplaatsBuitenland: '#/components/schemas/VerblijfplaatsBuitenlandVoorkomen'
+          Adres: '#/components/schemas/AdresVoorkomen'
+          VerblijfplaatsOnbekend: '#/components/schemas/VerblijfplaatsOnbekendVoorkomen'
+          Locatie: '#/components/schemas/LocatieVoorkomen'
+    VerblijfplaatsBuitenlandVoorkomen:
+      description: |
+        * **land** - land waar de persoon is overleden. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
+      allOf:
+      - $ref : '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          verblijfadres:
+            $ref: "verblijfplaats.yaml#/components/schemas/VerblijfadresBuitenland"
+          datumVan:
+            $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+          inOnderzoek:
+            $ref: '#/components/schemas/VerblijfplaatsBuitenlandVoorkomenInOnderzoek'
+          rni:
+            $ref: 'common.yaml#/components/schemas/RniDeelnemer'
+    AdresVoorkomen:
+      description: |
+        Gegevens over het adres voorkomen van een persoon.
+        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
+        * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
+        * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
+        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
+      allOf:
+        - $ref : '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+        - type: object
+          properties:
+            verblijfadres:
+              $ref: "verblijfplaats.yaml#/components/schemas/VerblijfadresBinnenland"
+            functieAdres:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            adresseerbaarObjectIdentificatie:
+              $ref: 'verblijfplaats.yaml#/components/schemas/AdresseerbaarObjectIdentificatie'
+            nummeraanduidingIdentificatie:
+              $ref: 'verblijfplaats.yaml#/components/schemas/NummeraanduidingIdentificatie'
+            gemeenteVanInschrijving:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            datumVan:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+            datumTot:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+            indicatieVastgesteldVerblijftNietOpAdres:
+              $ref: 'verblijfplaats.yaml#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
+            inOnderzoek:
+              $ref: "#/components/schemas/AdresVoorkomenInOnderzoek"
+    LocatieVoorkomen:
+      description: |
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
+        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+      allOf:
+        - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+        - type: object
+          properties:
+            datumVan:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+            datumTot:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+            functieAdres:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            verblijfadres:
+              $ref: "verblijfplaats.yaml#/components/schemas/VerblijfadresLocatie"
+            gemeenteVanInschrijving:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            indicatieVastgesteldVerblijftNietOpAdres:
+              $ref: 'verblijfplaats.yaml#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
+            inOnderzoek:
+              $ref: '#/components/schemas/LocatieVoorkomenInOnderzoek'
+    VerblijfplaatsOnbekendVoorkomen:
+      allOf:
+        - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+        - type: object
+          properties:
+            datumVan:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+            datumTot:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
+            inOnderzoek:
+              $ref: '#/components/schemas/VerblijfplaatsOnbekendVoorkomenInOnderzoek'
+            rni:
+              $ref: 'common.yaml#/components/schemas/RniDeelnemer'
+    GbaVerblijfplaatsVoorkomen:
+      allOf:
+        - $ref: 'verblijfplaats.yaml#/components/schemas/GbaVerblijfplaatsBeperkt'
+        - type: object
+          properties:
+            adresseerbaarObjectIdentificatie:
+              $ref: 'verblijfplaats.yaml#/components/schemas/AdresseerbaarObjectIdentificatie'
+            nummeraanduidingIdentificatie:
+              $ref: 'verblijfplaats.yaml#/components/schemas/NummeraanduidingIdentificatie'
+            datumAanvangAdresBuitenland:
+              $ref: 'datum.yaml#/components/schemas/GbaDatum'
+            datumAanvangVolgendeAdresBuitenland:
+              $ref: 'datum.yaml#/components/schemas/GbaDatum'
+            datumAanvangAdreshouding:
+              $ref: 'datum.yaml#/components/schemas/GbaDatum'
+            datumAanvangVolgendeAdreshouding:
+              $ref: 'datum.yaml#/components/schemas/GbaDatum'
+            functieAdres:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            naamOpenbareRuimte:
+              $ref: 'verblijfplaats.yaml#/components/schemas/NaamOpenbareRuimte'
+            gemeenteVanInschrijving:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            rni:
+              $ref: 'common.yaml#/components/schemas/RniDeelnemer'
+            inOnderzoekVolgendeVerblijfplaats:
+              $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
+    VerblijfplaatsBuitenlandVoorkomenInOnderzoek:
+      allOf:
+        - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
+        - type: object
+          properties:
+            type:
+              type: boolean
+            datumVan:
+              type: boolean
+            datumTot:
+              type: boolean
+    AdresVoorkomenInOnderzoek:
+      allOf:
+        - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
+        - type: object
+          properties:
+            type:
+              type: boolean
+            datumVan:
+              type: boolean
+            datumTot:
+              type: boolean
+            nummeraanduidingIdentificatie:
+              type: boolean
+            adresseerbaarObjectIdentificatie:
+              type: boolean
+            functieAdres:
+              type: boolean
+    VerblijfplaatsOnbekendVoorkomenInOnderzoek:
+      allOf:
+        - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
+        - type: object
+          properties:
+            type:
+              type: boolean
+            datumVan:
+              type: boolean
+            datumTot:
+              type: boolean
+    LocatieVoorkomenInOnderzoek:
+      allOf:
+        - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
+        - type: object
+          properties:
+            type:
+              type: boolean
+            gemeenteVanInschrijving:
+              type: boolean
+            datumVan:
+              type: boolean
+            datumTot:
+              type: boolean
+            functieAdres:
+              type: boolean

--- a/specificatie/verblijfplaats.yaml
+++ b/specificatie/verblijfplaats.yaml
@@ -299,8 +299,6 @@ components:
           properties:
             type:
               type: boolean
-            gemeenteVanInschrijving:
-              type: boolean
             datumVan:
               type: boolean
             datumTot:

--- a/specificatie/verblijfplaats.yaml
+++ b/specificatie/verblijfplaats.yaml
@@ -193,12 +193,10 @@ components:
             $ref: "#/components/schemas/VerblijfadresBuitenland"
           datumVan:
             $ref: 'datum.yaml#/components/schemas/AbstractDatum'
-          datumTot:
+          datumIngangGeldigheid:
             $ref: 'datum.yaml#/components/schemas/AbstractDatum'
           inOnderzoek:
             $ref: '#/components/schemas/VerblijfplaatsBuitenlandInOnderzoek'
-          rni:
-            $ref: 'common.yaml#/components/schemas/RniDeelnemer'
     Adres:
       description: |
         Gegevens over het adres van een persoon.
@@ -206,7 +204,7 @@ components:
         * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
         * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
         * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
-        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
+        * **datumIngangGeldigheid** : datum waarop de gegevens over de verblijfplaats geldig zijn geworden.
       allOf:
         - $ref : '#/components/schemas/AbstractVerblijfplaats'
         - type: object
@@ -219,11 +217,9 @@ components:
               $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
             nummeraanduidingIdentificatie:
               $ref: '#/components/schemas/NummeraanduidingIdentificatie'
-            gemeenteVanInschrijving:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
             datumVan:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
-            datumTot:
+            datumIngangGeldigheid:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             indicatieVastgesteldVerblijftNietOpAdres:
               $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
@@ -231,8 +227,8 @@ components:
               $ref: "#/components/schemas/AdresInOnderzoek"
     Locatie:
       description: |
-        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
         * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
         * **landVanWaarIngeschreven** : het land waar de persoon woonde voor (her)vestiging in Nederland. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
       allOf:
         - $ref: '#/components/schemas/AbstractVerblijfplaats'
@@ -240,14 +236,12 @@ components:
           properties:
             datumVan:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
-            datumTot:
-              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             functieAdres:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             verblijfadres:
               $ref: "#/components/schemas/VerblijfadresLocatie"
-            gemeenteVanInschrijving:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+            datumIngangGeldigheid:
+              $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             indicatieVastgesteldVerblijftNietOpAdres:
               $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
             inOnderzoek:
@@ -259,12 +253,10 @@ components:
           properties:
             datumVan:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
-            datumTot:
+            datumIngangGeldigheid:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             inOnderzoek:
               $ref: '#/components/schemas/VerblijfplaatsOnbekendInOnderzoek'
-            rni:
-              $ref: 'common.yaml#/components/schemas/RniDeelnemer'
     GbaVerblijfplaats:
       allOf:
         - $ref: '#/components/schemas/GbaVerblijfplaatsBeperkt'
@@ -276,22 +268,14 @@ components:
               $ref: '#/components/schemas/NummeraanduidingIdentificatie'
             datumAanvangAdresBuitenland:
               $ref: 'datum.yaml#/components/schemas/GbaDatum'
-            datumAanvangVolgendeAdresBuitenland:
-              $ref: 'datum.yaml#/components/schemas/GbaDatum'
             datumAanvangAdreshouding:
               $ref: 'datum.yaml#/components/schemas/GbaDatum'
-            datumAanvangVolgendeAdreshouding:
+            datumIngangGeldigheid:
               $ref: 'datum.yaml#/components/schemas/GbaDatum'
             functieAdres:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             naamOpenbareRuimte:
               $ref: '#/components/schemas/NaamOpenbareRuimte'
-            gemeenteVanInschrijving:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
-            rni:
-              $ref: 'common.yaml#/components/schemas/RniDeelnemer'
-            inOnderzoekVolgendeVerblijfplaats:
-              $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
     VerblijfplaatsBuitenlandInOnderzoek:
       allOf:
         - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
@@ -301,7 +285,7 @@ components:
               type: boolean
             datumVan:
               type: boolean
-            datumTot:
+            datumIngangGeldigheid:
               type: boolean
     VerblijfadresBuitenlandInOnderzoek:
       allOf:
@@ -344,11 +328,9 @@ components:
           properties:
             type:
               type: boolean
-            gemeenteVanInschrijving:
-              type: boolean
             datumVan:
               type: boolean
-            datumTot:
+            datumIngangGeldigheid:
               type: boolean
             nummeraanduidingIdentificatie:
               type: boolean
@@ -365,7 +347,7 @@ components:
               type: boolean
             datumVan:
               type: boolean
-            datumTot:
+            datumIngangGeldigheid:
               type: boolean
     LocatieInOnderzoek:
       allOf:
@@ -374,13 +356,11 @@ components:
           properties:
             type:
               type: boolean
-            gemeenteVanInschrijving:
-              type: boolean
             datumVan:
               type: boolean
-            datumTot:
-              type: boolean
             functieAdres:
+              type: boolean
+            datumIngangGeldigheid:
               type: boolean
     VerblijfadresLocatieInOnderzoek:
       allOf:
@@ -388,4 +368,11 @@ components:
         - type: object
           properties:
             locatiebeschrijving:
+              type: boolean
+    VerblijfplaatsInOnderzoekBeperkt:
+      allOf:
+        - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
+        - type: object
+          properties:
+            type:
               type: boolean

--- a/specificatie/verblijfplaats.yaml
+++ b/specificatie/verblijfplaats.yaml
@@ -191,8 +191,6 @@ components:
         properties:
           verblijfadres:
             $ref: "#/components/schemas/VerblijfadresBuitenland"
-          gemeenteVanInschrijving:
-            $ref: 'common.yaml#/components/schemas/Waardetabel'
           datumVan:
             $ref: 'datum.yaml#/components/schemas/AbstractDatum'
           datumTot:
@@ -208,6 +206,7 @@ components:
         * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
         * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
         * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
+        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
       allOf:
         - $ref : '#/components/schemas/AbstractVerblijfplaats'
         - type: object
@@ -230,8 +229,6 @@ components:
               $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
             inOnderzoek:
               $ref: "#/components/schemas/AdresInOnderzoek"
-            rni:
-              $ref: 'common.yaml#/components/schemas/RniDeelnemer'
     Locatie:
       description: |
         * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
@@ -255,8 +252,6 @@ components:
               $ref: '#/components/schemas/IndicatieVastgesteldVerblijftNietOpAdres'
             inOnderzoek:
               $ref: '#/components/schemas/LocatieInOnderzoek'
-            rni:
-              $ref: 'common.yaml#/components/schemas/RniDeelnemer'
     VerblijfplaatsOnbekend:
       allOf:
         - $ref: '#/components/schemas/AbstractVerblijfplaats'
@@ -281,14 +276,22 @@ components:
               $ref: '#/components/schemas/NummeraanduidingIdentificatie'
             datumAanvangAdresBuitenland:
               $ref: 'datum.yaml#/components/schemas/GbaDatum'
+            datumAanvangVolgendeAdresBuitenland:
+              $ref: 'datum.yaml#/components/schemas/GbaDatum'
             datumAanvangAdreshouding:
+              $ref: 'datum.yaml#/components/schemas/GbaDatum'
+            datumAanvangVolgendeAdreshouding:
               $ref: 'datum.yaml#/components/schemas/GbaDatum'
             functieAdres:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             naamOpenbareRuimte:
               $ref: '#/components/schemas/NaamOpenbareRuimte'
+            gemeenteVanInschrijving:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
             rni:
               $ref: 'common.yaml#/components/schemas/RniDeelnemer'
+            inOnderzoekVolgendeVerblijfplaats:
+              $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
     VerblijfplaatsBuitenlandInOnderzoek:
       allOf:
         - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
@@ -299,6 +302,8 @@ components:
             gemeenteVanInschrijving:
               type: boolean
             datumVan:
+              type: boolean
+            datumTot:
               type: boolean
     VerblijfadresBuitenlandInOnderzoek:
       allOf:
@@ -345,6 +350,8 @@ components:
               type: boolean
             datumVan:
               type: boolean
+            datumTot:
+              type: boolean
             nummeraanduidingIdentificatie:
               type: boolean
             adresseerbaarObjectIdentificatie:
@@ -360,6 +367,8 @@ components:
               type: boolean
             datumVan:
               type: boolean
+            datumTot:
+              type: boolean
     LocatieInOnderzoek:
       allOf:
         - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
@@ -370,6 +379,8 @@ components:
             gemeenteVanInschrijving:
               type: boolean
             datumVan:
+              type: boolean
+            datumTot:
               type: boolean
             functieAdres:
               type: boolean


### PR DESCRIPTION
Wijzigingen:
- [X] verwijderen fields parameter
- [X] toevoegen exclusiefVerblijfplaatsBuitenland parameter
- [X] verblijfplaats.yaml gelijk maken aan verblijfplaats.yaml in brp bevragen repo tbv uniformiteit
- [X] toevoegen van verblijfplaats-voorkomen.yaml. Hier staan de VerblijfplaatsVoorkomen schema componenten gespecificeerd. Deze componenten zijn afgeleide Verblijfplaats componenten met de volgende wijzigingen:

toegevoegde velden aan GbaVerblijfplaatsVoorkomen:
- [X] datumAanvangVolgendeAdreshouding
- [X] datumAanvangVolgendeAdresBuitenland
- [X] gemeenteVanInschrijving
- [X] inOnderzoekVolgendeVerblijfplaats

toegevoegde velden aan VerblijfplaatsBuitenlandVoorkomen en VerblijfplaatsOnbekendVoorkomen:
- [X] rni
- [X] inOnderzoek.datumTot

toegevoegde veld aan AdresVoorkomen en LocatieVoorkomen:
- [X] inOnderzoek.datumTot

verwijderde velden bij VerblijfplaatsBuitenlandVoorkomen, VerblijfplaatsOnbekendVoorkomen, AdresVoorkomen en LocatieVoorkomen:
- [X] datumIngangGeldigheid
