### PR TITLE
aanpassen url naar API

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -13,8 +13,8 @@
     "version" : "2.0.0"
   },
   "servers" : [ {
-    "url" : "https://www.haalcentraal.nl/haalcentraal/api/brphistorie",
-    "description" : "APILAB testserver historie"
+    "url" : "https://apigw.npr.idm.diginetwerk.net/lap/api/brp",
+    "description" : "RvIG Proefomgeving"
   } ],
   "tags" : [ {
     "name" : "BRP historie bevragen",

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -12,8 +12,8 @@ info:
     url: https://eupl.eu/1.2/nl/
   version: 2.0.0
 servers:
-- url: https://www.haalcentraal.nl/haalcentraal/api/brphistorie
-  description: APILAB testserver historie
+- url: https://apigw.npr.idm.diginetwerk.net/lap/api/brp
+  description: RvIG Proefomgeving
 tags:
 - name: BRP historie bevragen
   description: Zoeken historische gegevens

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 servers:
-  - description: "APILAB testserver historie"
-    url: https://www.haalcentraal.nl/haalcentraal/api/brphistorie
+  - description: "RvIG Proefomgeving"
+    url: https://apigw.npr.idm.diginetwerk.net/lap/api/brp
 info:
   title: BRP historie bevragen
   description: |


### PR DESCRIPTION
er werd nog verwezen naar een API-lab server. Handiger is denk ik om de url naar de RvIG proefomgeving op te nemen, en daarnaast -straks- naar de demo-omgeving met een juiste url

Ik heb voor nu de url naar de RvIG proefomgeving opgenomen