### PR TITLE
Antora documentatie

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,0 +1,24 @@
+name: brp-api
+version: ~
+title: BRP API
+asciidoc:
+  attributes:
+    apiname: BRP API
+    po-email: cathy.dingemanse@rvig.nl
+    cz-email: melvin.lee@rvig.nl
+    tester-email: frank.samwel@rvig.nl
+    main-branch-url: https://github.com/BRP-API/Haal-Centraal-BRP-bevragen/blob/master
+    base-url: /Haal-Centraal-BRP-bevragen
+    pages-base-url: https://BRP-API.github.io
+    repo-url: https://github.com/BRP-API/Haal-Centraal-BRP-bevragen
+    dev-branch-url: https://github.com/BRP-API/Haal-Centraal-BRP-bevragen/blob/develop
+    personen-spec-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bevragen/master/specificatie/resolved/openapi.yaml
+    bewoning-spec-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bewoning/master/specificatie/resolved/openapi.yaml
+    verblijfplaatshistorie-spec-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-historie-bevragen/master/specificatie/genereervariant/openapi.yaml
+    onboarding-url: https://github.com/BRP-API/Haal-Centraal-BRP-bevragen/blob/master/docs/240507%20deelname%20BRP%20API%20v2.4.ppsx
+    proef-proxy-url: https://proefomgeving.haalcentraal.nl
+    persoon-fields-csv-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bevragen/master/features/fields-filtered-Persoon.csv
+    persoon-beperkt-fields-csv-url: https://raw.githubusercontent.com/BRP-API/Haal-Centraal-BRP-bevragen/master/features/fields-filtered-PersoonBeperkt.csv
+    po-naam: Cathy Dingemanse
+    rvig-email: info@rvig.nl
+    organisation-url: http://www.rvig.nl

--- a/features/raadpleeg-verblijfplaats-met-periode/datum-van-en-tot.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/datum-van-en-tot.feature
@@ -1,0 +1,192 @@
+#language: nl
+
+@proxy @geen-protocollering @valideer-volgorde
+Functionaliteit: leveren van datumVan en datumTot voor geleverde verblijfplaatsen
+
+    Achtergrond:
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0800                 | 0800010000000001                         | Teststraat         | 1                  |
+      En adres 'A2' heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0800                 | 0800010000000002                         | Andere Teststraat  | 2                  |
+
+
+    Scenario: actuele en historische verblijfplaatsen
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20231014                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2023-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | verblijfadres.korteStraatnaam | verblijfadres.huisnummer | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 |
+      | Adres | Datum         | 2023-10-14     | 14 oktober 2023      |               |                |                      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 | Andere Teststraat             | 2                        | W                 | woonadres                 | Andere Teststraat 2     |
+      | Adres | Datum         | 2021-05-26     | 26 mei 2021          | Datum         | 2023-10-14     | 14 oktober 2023      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 | Teststraat                    | 1                        | W                 | woonadres                 | Teststraat 1            |
+
+    Scenario: verblijfplaatsen in Nederland en in buitenland
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+      | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+      | 20220730                               | 6014                          |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20231014                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2023-10-14     | 14 oktober 2023      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | korteStraatnaam   | huisnummer |
+      | Andere Teststraat | 2          |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | adresregel1         |
+      | Andere Teststraat 2 |
+      En heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type                     | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat |
+      | VerblijfplaatsBuitenland | Datum         | 2022-07-30     | 30 juli 2022         | Datum         | 2023-10-14     | 14 oktober 2023      |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | land.code | land.omschrijving            |
+      | 6014      | Verenigde Staten van Amerika |
+      En heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-05-26     | 26 mei 2021          | Datum         | 2022-07-30     | 30 juli 2022         | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | korteStraatnaam | huisnummer |
+      | Teststraat      | 1          |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | adresregel1  |
+      | Teststraat 1 |
+
+    Scenario: verblijfplaats in Nederland heeft datum aanvang met alleen jaar en maand bekend
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20231000                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type  | datumVan.type  | datumVan.datum | datumVan.jaar | datumVan.maand | datumVan.langFormaat | datumTot.type  | datumTot.jaar | datumTot.maand | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 | verblijfadres.korteStraatnaam | verblijfadres.huisnummer |
+      | Adres | JaarMaandDatum |                | 2023          | 10             | oktober 2023         |                |               |                |                      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 | W                 | woonadres                 | Andere Teststraat 2     | Andere Teststraat             | 2                        |
+      | Adres | Datum          | 2021-05-26     |               |                | 26 mei 2021          | JaarMaandDatum | 2023          | 10             | oktober 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 | W                 | woonadres                 | Teststraat 1            | Teststraat                    | 1                        |
+
+    Scenario: verblijfplaats in Nederland heeft datum aanvang met alleen jaar bekend
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20230000                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.jaar | datumVan.langFormaat | datumTot.type | datumTot.jaar | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 | verblijfadres.korteStraatnaam | verblijfadres.huisnummer |
+      | Adres | JaarDatum     |                | 2023          | 2023                 |               |               |                      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 | W                 | woonadres                 | Andere Teststraat 2     | Andere Teststraat             | 2                        |
+      | Adres | Datum         | 2021-05-26     |               | 26 mei 2021          | JaarDatum     | 2023          | 2023                 | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 | W                 | woonadres                 | Teststraat 1            | Teststraat                    | 1                        |
+
+    Scenario: verblijfplaats in Nederland heeft datum aanvang is onbekend
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20220526                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 00000000                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumVan.onbekend | datumTot.type | datumTot.langFormaat | datumTot.onbekend | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 | verblijfadres.korteStraatnaam | verblijfadres.huisnummer |
+      | Adres | DatumOnbekend |                | onbekend             | true              |               |                      |                   | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 | W                 | woonadres                 | Andere Teststraat 2     | Andere Teststraat             | 2                        |
+      | Adres | Datum         | 2022-05-26     | 26 mei 2022          |                   | DatumOnbekend | onbekend             | true              | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 | W                 | woonadres                 | Teststraat 1            | Teststraat                    | 1                        |
+
+    Scenario: verblijfplaats buitenland heeft datum aanvang met alleen jaar en maand bekend
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+      | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+      | 20220700                               | 6014                          |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20231014                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type                     | datumVan.type  | datumVan.datum | datumVan.jaar | datumVan.maand | datumVan.langFormaat | datumTot.type  | datumTot.datum | datumTot.jaar | datumTot.maand | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | verblijfadres.land.code | verblijfadres.land.omschrijving | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 | verblijfadres.korteStraatnaam | verblijfadres.huisnummer |
+      | Adres                    | Datum          | 2023-10-14     |               |                | 14 oktober 2023      |                |                |               |                |                      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 |                         |                                 | W                 | woonadres                 | Andere Teststraat 2     | Andere Teststraat             | 2                        |
+      | VerblijfplaatsBuitenland | JaarMaandDatum |                | 2022          | 7              | juli 2022            | Datum          | 2023-10-14     |               |                | 14 oktober 2023      |                              |                                      |                                  | 6014                    | Verenigde Staten van Amerika    |                   |                           |                         |                               |                          |
+      | Adres                    | Datum          | 2021-05-26     |               |                | 26 mei 2021          | JaarMaandDatum |                | 2022          | 7              | juli 2022            | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 |                         |                                 | W                 | woonadres                 | Teststraat 1            | Teststraat                    | 1                        |
+
+    Scenario: verblijfplaats buitenland heeft datum aanvang met alleen jaar bekend
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+      | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+      | 20220000                               | 6014                          |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20231014                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2021-12-31          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type                     | datumVan.type | datumVan.datum | datumVan.jaar | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.jaar | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | verblijfadres.land.code | verblijfadres.land.omschrijving | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 | verblijfadres.korteStraatnaam | verblijfadres.huisnummer |
+      | Adres                    | Datum         | 2023-10-14     |               | 14 oktober 2023      |               |                |               |                      | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 |                         |                                 | W                 | woonadres                 | Andere Teststraat 2     | Andere Teststraat             | 2                        |
+      | VerblijfplaatsBuitenland | JaarDatum     |                | 2022          | 2022                 | Datum         | 2023-10-14     |               | 14 oktober 2023      |                              |                                      |                                  | 6014                    | Verenigde Staten van Amerika    |                   |                           |                         |                               |                          |
+      | Adres                    | Datum         | 2021-05-26     |               | 26 mei 2021          | JaarDatum     |                | 2022          | 2022                 | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 |                         |                                 | W                 | woonadres                 | Teststraat 1            | Teststraat                    | 1                        |
+
+    Scenario: verblijfplaats buitenland heeft datum aanvang is onbekend
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20210526                           |
+      En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+      | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+      | 00000000                               | 6014                          |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20231014                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2021-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type                     | datumVan.type | datumVan.datum | datumVan.langFormaat | datumVan.onbekend | datumTot.type | datumTot.datum | datumTot.langFormaat | datumTot.onbekend | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | adresseerbaarObjectIdentificatie | verblijfadres.land.code | verblijfadres.land.omschrijving | functieAdres.code | functieAdres.omschrijving | adressering.adresregel1 | verblijfadres.korteStraatnaam | verblijfadres.huisnummer |
+      | Adres                    | Datum         | 2023-10-14     | 14 oktober 2023      |                   |               |                |                      |                   | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000002                 |                         |                                 | W                 | woonadres                 | Andere Teststraat 2     | Andere Teststraat             | 2                        |
+      | VerblijfplaatsBuitenland | DatumOnbekend |                | onbekend             | true              | Datum         | 2023-10-14     | 14 oktober 2023      |                   |                              |                                      |                                  | 6014                    | Verenigde Staten van Amerika    |                   |                           |                         |                               |                          |
+      | Adres                    | Datum         | 2021-05-26     | 26 mei 2021          |                   | DatumOnbekend |                | onbekend             | true              | 0800                         | Hoogeloon, Hapert en Casteren        | 0800010000000001                 |                         |                                 | W                 | woonadres                 | Teststraat 1            | Teststraat                    | 1                        |

--- a/features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.feature
@@ -1,0 +1,331 @@
+#language: nl 
+
+@proxy @geen-protocollering
+Functionaliteit: persoon met 'indicatie vastgesteld verblijft niet op adres' bij verblijfplaatshistorie met periode
+
+  Een burger kan bij de gemeente melden dat iemand anders ten onrechte op diens adres staat ingeschreven. 
+  De gemeente doet daar dan onderzoek naar en kan concluderen dat deze andere persoon inderdaad niet meer op dat adres verblijft. 
+  Wanneer tijdens de uitvoer van het onderzoek vastgesteld wordt dat een persoon niet meer woont op het adres waarop hij is ingeschreven in de BRP, 
+  kan dit deel van het onderzoeksresultaat al worden opgenomen op de persoonslijst van de persoon. 
+  Dit wordt gedaan door het zetten van aanduiding onderzoek 089999.
+  Hiermee wordt geregistreerd dat is vastgesteld dat een persoon niet (langer) op het adres verblijft waarop hij ingeschreven staat, 
+  maar dat het onderzoek naar het (nieuwe) woonadres nog loopt.
+  Hierdoor kunnen eventuele problemen voor de nieuwe of oude medebewoners voorkomen worden.
+  In de verblijfplaatshistorie leveren we dan de verblijfplaats met indicatieVastgesteldVerblijftNietOpAdres en datumVan is gelijk aan de datum ingang van het onderzoek.
+
+  Wanneer onderzoek is afgesloten moet normaal gesproken worden aangenomen dat de resultaten van het onderzoek in de registratie zijn verwerkt.
+  Het feit dat er een beëindigd onderzoek is met aanduiding vastgesteld geen bewoner meer (089999) kan dan worden genegeerd.
+  
+  Het kan echter voorkomen dat dit onderzoek wordt gesloten zonder dat het onderzoek inhoudelijk is afgerond. 
+  Dit kan bijvoorbeeld gebeuren nadat de betreffende persoon zich inschrijft in een andere gemeente. 
+  Deze andere gemeente zal of kan het onderzoek naar verblijf voor inschrijving in die gemeente vaak niet onderzoeken.
+  Het onderzoek wordt dan in de registratie gesloten zonder dat is vastgesteld dat de registratie van verblijfplaatsen correct is.
+  De aanduiding vastgesteld geen bewoner meer is dan nog steeds van belang, ook al is het onderzoek beëindigd.
+
+  Wanneer onderzoek is beëindigd voor de datum aanvang van een volgend verblijf kunnen we zeker aannemen dat het onderzoek ook inhoudelijk afgerond is.
+  Wanneer onderzoek is beëindigd op of na de datum aanvang van een volgend verblijf kunnen we niet met zekerheid zeggen of het onderzoek inhoudelijk afgerond is dan wel alleen administratie afgerond.
+  In dat geval leveren we verblijftNietOpAdresVanaf met de datum dat vastgesteld verblijft niet op adres is vastgelegd.
+
+
+    Achtergrond:
+      Gegeven adres 'A1' heeft de volgende gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | postcode (11.60) |
+      | 0800                 | Testpad            | 8                  | 1234AB           |
+      En adres 'A2' heeft de volgende gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | postcode (11.60) |
+      | 0800                 | Voorbeeldstraat    | 2                  | 1234AC           |
+
+
+  Regel: bij een lopend onderzoek met aanduiding 089999 of 589999 wordt verblijftNietOpAdresVanaf geleverd met als waarde de datum ingang van het onderzoek
+
+    Abstract Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en het onderzoek loopt nog en <omschrijving>
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
+      | 0800                              | 20211014                           | <aanduiding onderzoek>          | 20230516                       |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2023-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijftNietOpAdresVanaf' gegevens
+      | naam        | waarde      |
+      | type        | Datum       |
+      | datum       | 2023-05-16  |
+      | langFormaat | 16 mei 2023 |
+      En heeft het verblijfplaats voorkomen de volgende 'inOnderzoek' gegevens
+      | naam                             | waarde      |
+      | type                             | true        |
+      | gemeenteVanInschrijving          | true        |
+      | datumVan                         | true        |
+      | nummeraanduidingIdentificatie    | true        |
+      | adresseerbaarObjectIdentificatie | true        |
+      | functieAdres                     | true        |
+      | datumIngangOnderzoek.type        | Datum       |
+      | datumIngangOnderzoek.datum       | 2023-05-16  |
+      | datumIngangOnderzoek.langFormaat | 16 mei 2023 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam                                         | waarde      |
+      | korteStraatnaam                              | Testpad     |
+      | huisnummer                                   | 8           |
+      | postcode                                     | 1234AB      |
+      | inOnderzoek.korteStraatnaam                  | true        |
+      | inOnderzoek.officieleStraatnaam              | true        |
+      | inOnderzoek.huisnummer                       | true        |
+      | inOnderzoek.huisletter                       | true        |
+      | inOnderzoek.huisnummertoevoeging             | true        |
+      | inOnderzoek.aanduidingBijHuisnummer          | true        |
+      | inOnderzoek.postcode                         | true        |
+      | inOnderzoek.woonplaats                       | true        |
+      | inOnderzoek.datumIngangOnderzoek.type        | Datum       |
+      | inOnderzoek.datumIngangOnderzoek.datum       | 2023-05-16  |
+      | inOnderzoek.datumIngangOnderzoek.langFormaat | 16 mei 2023 |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam                                         | waarde                                 |
+      | adresregel1                                  | Testpad 8                              |
+      | adresregel2                                  | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+      | inOnderzoek.adresregel1                      | true                                   |
+      | inOnderzoek.adresregel2                      | true                                   |
+      | inOnderzoek.datumIngangOnderzoek.type        | Datum                                  |
+      | inOnderzoek.datumIngangOnderzoek.datum       | 2023-05-16                             |
+      | inOnderzoek.datumIngangOnderzoek.langFormaat | 16 mei 2023                            |
+
+      Voorbeelden:
+      | aanduiding onderzoek | datum van  | datum tot  | omschrijving                                       |
+      | 089999               | 2023-01-01 | 2024-01-01 | periode overlapt de datum ingang van het onderzoek |
+      | 589999               | 2022-01-01 | 2023-01-01 | periode ligt voor de start van het onderzoek       |
+
+
+  Regel: bij een beëindigd onderzoek met aanduiding 089999 of 589999 en datum einde van het onderzoek ligt voor datum aanvang van het volgende verblijf worden verblijftNietOpAdresVanaf en het onderzoek niet geleverd
+
+    Abstract Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en het onderzoek is beëindigd voor datum aanvang van de volgende verblijfplaats in Nederland
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum einde onderzoek (83.30) |
+      | 0800                              | 20211014                           | <aanduiding onderzoek>          | 20230516                       | 20230729                      |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20230730                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2023-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde          |
+      | korteStraatnaam | Voorbeeldstraat |
+      | huisnummer      | 2               |
+      | postcode        | 1234AC          |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Voorbeeldstraat 2                      |
+      | adresregel2 | 1234 AC  HOOGELOON, HAPERT EN CASTEREN |
+      En heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde  |
+      | korteStraatnaam | Testpad |
+      | huisnummer      | 8       |
+      | postcode        | 1234AB  |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Testpad 8                              |
+      | adresregel2 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+
+      Voorbeelden:
+      | aanduiding onderzoek |
+      | 089999               |
+      | 589999               |
+
+    Abstract Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en het onderzoek is beëindigd voor datum vertrek met onbekende verblijfplaats
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum einde onderzoek (83.30) |
+      | 0800                              | 20211014                           | <aanduiding onderzoek>          | 20230516                       | 20230729                      |
+      En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+      | 1999                              | 20230730                               | 0000                          |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2023-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type                   | datumVan.type | datumVan.datum | datumVan.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving |
+      | VerblijfplaatsOnbekend | Datum         | 2023-07-30     | 30 juli 2023         | 1999                         | Registratie Niet Ingezetenen (RNI)   |
+      En heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde  |
+      | korteStraatnaam | Testpad |
+      | huisnummer      | 8       |
+      | postcode        | 1234AB  |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Testpad 8                              |
+      | adresregel2 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+
+      Voorbeelden:
+      | aanduiding onderzoek |
+      | 089999               |
+      | 589999               |
+
+
+  Regel: bij een beëindigd onderzoek met aanduiding 089999 of 589999 en datum einde van het onderzoek ligt op of na datum aanvang van het volgende verblijf wordt verblijftNietOpAdresVanaf geleverd met als waarde de datum ingang van het onderzoek
+
+    Abstract Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en het onderzoek is beëindigd <op of na> datum aanvang van de volgende verblijfplaats in Nederland
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum einde onderzoek (83.30) |
+      | 0800                              | 20211014                           | <aanduiding onderzoek>          | 20230516                       | <datum einde onderzoek>       |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20230730                           |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2023-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde          |
+      | korteStraatnaam | Voorbeeldstraat |
+      | huisnummer      | 2               |
+      | postcode        | 1234AC          |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Voorbeeldstraat 2                      |
+      | adresregel2 | 1234 AC  HOOGELOON, HAPERT EN CASTEREN |
+      En heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijftNietOpAdresVanaf' gegevens
+      | naam        | waarde      |
+      | type        | Datum       |
+      | datum       | 2023-05-16  |
+      | langFormaat | 16 mei 2023 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam                                         | waarde      |
+      | korteStraatnaam                              | Testpad     |
+      | huisnummer                                   | 8           |
+      | postcode                                     | 1234AB      |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam                                         | waarde                                 |
+      | adresregel1                                  | Testpad 8                              |
+      | adresregel2                                  | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+
+      Voorbeelden:
+      | aanduiding onderzoek | op of na | datum einde onderzoek |
+      | 089999               | op       | 20230730              |
+      | 589999               | op       | 20230730              |
+      | 089999               | na       | 20230731              |
+      | 589999               | na       | 20230731              |
+
+    Abstract Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en het onderzoek is beëindigd na datum vertrek met onbekende verblijfplaats en periode ligt voor de start van het onderzoek
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum einde onderzoek (83.30) |
+      | 0800                              | 20211014                           | <aanduiding onderzoek>          | 20230516                       | <datum einde onderzoek>       |
+      En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+      | 1999                              | 20230730                               | 0000                          |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2023-01-01          |
+      Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijftNietOpAdresVanaf' gegevens
+      | naam        | waarde      |
+      | type        | Datum       |
+      | datum       | 2023-05-16  |
+      | langFormaat | 16 mei 2023 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde  |
+      | korteStraatnaam | Testpad |
+      | huisnummer      | 8       |
+      | postcode        | 1234AB  |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Testpad 8                              |
+      | adresregel2 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+
+      Voorbeelden:
+      | aanduiding onderzoek | op of na | datum einde onderzoek |
+      | 089999               | op       | 20230730              |
+      | 589999               | op       | 20230730              |
+      | 089999               | na       | 20230731              |
+      | 589999               | na       | 20230731              |
+
+
+  Regel: bij een beëindigd onderzoek met aanduiding 089999 of 589999 op de actuele verblijfplaats wordt het onderzoek niet geleverd
+
+    Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en het onderzoek is beëindigd en er is geen volgende verblijfplaats
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum einde onderzoek (83.30) |
+      | 0800                              | 20211014                           | <aanduiding onderzoek>          | 20230516                       | 20230730                      |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2023-01-01          |
+      | datumTot            | 2024-01-01          |
+      Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde  |
+      | korteStraatnaam | Testpad |
+      | huisnummer      | 8       |
+      | postcode        | 1234AB  |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Testpad 8                              |
+      | adresregel2 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+
+      Voorbeelden:
+      | aanduiding onderzoek |
+      | 089999               |
+      | 589999               |
+    
+  Regel: vastgesteld verblijft niet op adres op de volgende verblijfplaats wordt niet geleverd
+    De aanduiding onderzoek vastgesteld verblijft niet langer op adres kan nooit betrekking hebben op de datum aanvang van dat adres,
+    en dus kan het geen betrekking hebben op de datum tot van het vorige verblijf.
+
+    Scenario: er is vastgesteld dat de persoon niet meer op het adres verblijft en de periode valt in het vorige verblijf
+      Gegeven de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+      | 0800                              | 20211014                           |
+      En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+      | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
+      | 0800                              | 20230730                           | 089999                          | 20230516                       |
+      Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+      | naam                | waarde              |
+      | type                | RaadpleegMetPeriode |
+      | burgerservicenummer | 000000012           |
+      | datumVan            | 2022-01-01          |
+      | datumTot            | 2023-01-01          |
+      Dan heeft de response verblijfplaatsen met de volgende gegevens
+      | type  | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving |
+      | Adres | Datum         | 2021-10-14     | 14 oktober 2021      | Datum         | 2023-07-30     | 30 juli 2023         | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 |
+      En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+      | naam            | waarde  |
+      | korteStraatnaam | Testpad |
+      | huisnummer      | 8       |
+      | postcode        | 1234AB  |
+      En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+      | naam        | waarde                                 |
+      | adresregel1 | Testpad 8                              |
+      | adresregel2 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |

--- a/features/raadpleeg-verblijfplaats-met-periode/verblijfplaatsgegevens.feature
+++ b/features/raadpleeg-verblijfplaats-met-periode/verblijfplaatsgegevens.feature
@@ -1,0 +1,194 @@
+#language: nl
+
+@proxy @geen-protocollering
+Functionaliteit: alle gegevens van verblijfplaatsen worden geleverd bij raadplegen op periode
+
+  Scenario: verblijfplaats is een BAG-adres
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (11.10) | naam openbare ruimte (11.15) | huisnummer (11.20) | huisletter (11.30) | huisnummertoevoeging (11.40) | postcode (11.60) | woonplaats (11.70) | identificatiecode verblijfplaats (11.80) | identificatiecode nummeraanduiding (11.90) |
+    | 0800                 | Teststraat         | Test Openbare Ruimtenaam     | 123                | B                  | 4567                         | 1234AB           | Testdorp           | 0800010000000001                         | 0800200000000001                           |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | 2011-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type  | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat | adresseerbaarObjectIdentificatie | nummeraanduidingIdentificatie |
+    | Adres | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 | Datum         | 2010-08-18     | 18 augustus 2010     | 0800010000000001                 | 0800200000000001              |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | korteStraatnaam | officieleStraatnaam      | huisnummer | huisletter | huisnummertoevoeging | postcode | woonplaats |
+    | Teststraat      | Test Openbare Ruimtenaam | 123        | B          | 4567                 | 1234AB   | Testdorp   |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1          | adresregel2       |
+    | Teststraat 123 B4567 | 1234 AB  TESTDORP |
+
+  Scenario: verblijfplaats is een historische BAG-adres
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (11.10) | naam openbare ruimte (11.15) | huisnummer (11.20) | huisletter (11.30) | huisnummertoevoeging (11.40) | postcode (11.60) | woonplaats (11.70) | identificatiecode verblijfplaats (11.80) | identificatiecode nummeraanduiding (11.90) |
+    | 0800                 | Teststraat         | Test Openbare Ruimtenaam     | 123                | B                  | 4567                         | 1234AB           | Testdorp           | 0800010000000001                         | 0800200000000001                           |
+    En adres 'A2' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (11.10) | naam openbare ruimte (11.15) | huisnummer (11.20) | huisletter (11.30) | huisnummertoevoeging (11.40) | postcode (11.60) | woonplaats (11.70) | identificatiecode verblijfplaats (11.80) | identificatiecode nummeraanduiding (11.90) |
+    | 0800                 | Andere Teststraat  | Test Ander Ruimtenaam        | 1234               | C                  | 5678                         | 1234CD           | Testdorp           | 0800010000000002                         | 0800200000000002                           |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20110101                           |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | 2011-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type  | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat | datumTot.type | datumTot.datum | datumTot.langFormaat | adresseerbaarObjectIdentificatie | nummeraanduidingIdentificatie |
+    | Adres | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 | Datum         | 2010-08-18     | 18 augustus 2010     | Datum         | 2011-01-01     | 1 januari 2011       |0800010000000001                 | 0800200000000001              |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | korteStraatnaam | officieleStraatnaam      | huisnummer | huisletter | huisnummertoevoeging | postcode | woonplaats |
+    | Teststraat      | Test Openbare Ruimtenaam | 123        | B          | 4567                 | 1234AB   | Testdorp   |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1          | adresregel2       |
+    | Teststraat 123 B4567 | 1234 AB  TESTDORP |
+
+  Scenario: verblijfplaats is een niet-BAG adres
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | huisletter (11.30) | huisnummertoevoeging (11.40) | aanduiding bij huisnummer (11.50) | postcode (11.60) |
+    | 0800                 | Teststraat         | 123                | B                  | 4567                         | by                                | 1234AB           |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | 2011-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type  | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat |
+    | Adres | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 | Datum         | 2010-08-18     | 18 augustus 2010     |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | korteStraatnaam | huisnummer | huisletter | huisnummertoevoeging | aanduidingBijHuisnummer.code | aanduidingBijHuisnummer.omschrijving | postcode |
+    | Teststraat      | 123        | B          | 4567                 | by                           | bij                                  | 1234AB   |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1              | adresregel2                            |
+    | Teststraat bij 123 B4567 | 1234 AB  HOOGELOON, HAPERT EN CASTEREN |
+
+  Scenario: verblijfplaats heeft diakrieten in adres
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (diakrieten) | naam openbare ruimte (diakrieten) | huisnummer (11.20) | postcode (11.60) | woonplaats (diakrieten) | identificatiecode verblijfplaats (11.80) | identificatiecode nummeraanduiding (11.90) |
+    | 0800                 | Contrôle                | Tést Openbare Ruimtenaam          | 123                | 1234AB           | Testdörp                | 0800010000000001                         | 0800200000000001                           |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | 2011-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type  | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat | adresseerbaarObjectIdentificatie | nummeraanduidingIdentificatie |
+    | Adres | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 | Datum         | 2010-08-18     | 18 augustus 2010     | 0800010000000001                 | 0800200000000001              |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | korteStraatnaam | officieleStraatnaam      | huisnummer | postcode | woonplaats |
+    | Contrôle        | Tést Openbare Ruimtenaam | 123        | 1234AB   | Testdörp   |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1  | adresregel2       |
+    | Contrôle 123 | 1234 AB  TESTDÖRP |
+
+  Scenario: verblijfplaats is locatie
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | locatiebeschrijving (12.10) |
+    | 0800                 | Woonboot bij de Grote Sloot |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | 2011-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type    | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat |
+    | Locatie | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 | Datum         | 2010-08-18     | 18 augustus 2010     |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | locatiebeschrijving         |
+    | Woonboot bij de Grote Sloot |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1                 | adresregel2                   |
+    | Woonboot bij de Grote Sloot | HOOGELOON, HAPERT EN CASTEREN |
+
+  Scenario: verblijfplaats is locatie met diakrieten
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | locatiebeschrijving (diakrieten) |
+    | 0800                 | Woonboot bij de Græte Slüß       |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20100818                           |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2010-01-01          |
+    | datumTot            | 2011-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type    | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | functieAdres.code | functieAdres.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat |
+    | Locatie | 0800                         | Hoogeloon, Hapert en Casteren        | W                 | woonadres                 | Datum         | 2010-08-18     | 18 augustus 2010     |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | locatiebeschrijving        |
+    | Woonboot bij de Græte Slüß |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1                | adresregel2                   |
+    | Woonboot bij de Græte Slüß | HOOGELOON, HAPERT EN CASTEREN |
+
+  Scenario: verblijfplaats is buitenlands adres
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (11.10) | naam openbare ruimte (11.15) | huisnummer (11.20) | huisletter (11.30) | huisnummertoevoeging (11.40) | postcode (11.60) | woonplaats (11.70) | identificatiecode verblijfplaats (11.80) | identificatiecode nummeraanduiding (11.90) |
+    | 0800                 | Teststraat         | Test Openbare Ruimtenaam     | 123                | B                  | 4567                         | 1234AB           | Testdorp           | 0800010000000001                         | 0800200000000001                           |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20040526                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) | regel 1 adres buitenland (13.30) | regel 2 adres buitenland (13.40) | regel 3 adres buitenland (13.50) |
+    | 1999                              | 20100818                               | 6014                          | Die Erste Straße                 | Beverly Hills CA 90210           | Loin d'ici                       |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2011-01-01          |
+    | datumTot            | 2012-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type                     | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat |
+    | VerblijfplaatsBuitenland | 1999                         | Registratie Niet Ingezetenen (RNI)   | Datum         | 2010-08-18     | 18 augustus 2010     |
+    En heeft het verblijfplaats voorkomen de volgende 'verblijfadres' gegevens
+    | land.code | land.omschrijving            | regel1           | regel2                 | regel3     |
+    | 6014      | Verenigde Staten van Amerika | Die Erste Straße | Beverly Hills CA 90210 | Loin d'ici |
+    En heeft het verblijfplaats voorkomen de volgende 'adressering' gegevens
+    | adresregel1      | adresregel2            | adresregel3 | land.code | land.omschrijving            |
+    | Die Erste Straße | Beverly Hills CA 90210 | Loin d'ici  | 6014      | Verenigde Staten van Amerika |
+
+  Scenario: verblijfplaats is onbekend
+    Gegeven adres 'A1' heeft de volgende gegevens
+    | gemeentecode (92.10) | straatnaam (11.10) | naam openbare ruimte (11.15) | huisnummer (11.20) | huisletter (11.30) | huisnummertoevoeging (11.40) | postcode (11.60) | woonplaats (11.70) | identificatiecode verblijfplaats (11.80) | identificatiecode nummeraanduiding (11.90) |
+    | 0800                 | Teststraat         | Test Openbare Ruimtenaam     | 123                | B                  | 4567                         | 1234AB           | Testdorp           | 0800010000000001                         | 0800200000000001                           |
+    En de persoon met burgerservicenummer '000000012' is ingeschreven op adres 'A1' met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
+    | 0800                              | 20040526                           |
+    En de persoon is vervolgens ingeschreven op een buitenlands adres met de volgende gegevens
+    | gemeente van inschrijving (09.10) | datum aanvang adres buitenland (13.20) | land adres buitenland (13.10) |
+    | 1999                              | 20100818                               | 0000                          |
+    Als verblijfplaatshistorie wordt gezocht met de volgende parameters
+    | naam                | waarde              |
+    | type                | RaadpleegMetPeriode |
+    | burgerservicenummer | 000000012           |
+    | datumVan            | 2011-01-01          |
+    | datumTot            | 2012-01-01          |
+    Dan heeft de response een verblijfplaats voorkomen met de volgende gegevens
+    | type                   | gemeenteVanInschrijving.code | gemeenteVanInschrijving.omschrijving | datumVan.type | datumVan.datum | datumVan.langFormaat |
+    | VerblijfplaatsOnbekend | 1999                         | Registratie Niet Ingezetenen (RNI)   | Datum         | 2010-08-18     | 18 augustus 2010     |

--- a/modules/historie/attachments/openapi.yaml
+++ b/modules/historie/attachments/openapi.yaml
@@ -1,0 +1,135 @@
+openapi: 3.0.3
+servers:
+  - description: "RvIG Proefomgeving"
+    url: https://apigw.npr.idm.diginetwerk.net/lap/api/brp
+info:
+  title: BRP historie bevragen
+  description: |
+                API voor het zoeken en raadplegen van historische verblijfplaatsen, partners, nationaliteiten en verblijfstitels uit de BRP (inclusief de RNI).
+
+                Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/tree/v1.0.0/features) voor nadere toelichting.
+  version: 2.0.0
+  contact:
+    url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen
+  license:
+    name: European Union Public License, version 1.2 (EUPL-1.2)
+    url: https://eupl.eu/1.2/nl/
+tags:
+  - name: BRP historie bevragen
+    description: Zoeken historische gegevens
+paths:
+  /verblijfplaatshistorie:
+    post:
+      description: |
+        Raadpleeg de verblijfplaatshistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.
+        Het meest actuele adres staat bovenaan.
+
+        Zoek met burgerservicenummer
+      operationId: Verblijfplaatshistorie
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HistorieQuery"
+      responses:
+        '200':
+          description: |
+                        Zoekactie geslaagd
+          headers:
+            warning:
+              $ref: "common.yaml#/components/headers/warning"
+            X-Rate-Limit-Limit:
+              $ref: "common.yaml#/components/headers/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "common.yaml#/components/headers/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "common.yaml#/components/headers/X_Rate_Limit_Reset"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerblijfplaatshistorieQueryResponse"
+        '400':
+          $ref: "common.yaml#/components/responses/400"
+        '401':
+          $ref: "common.yaml#/components/responses/401"
+        '403':
+          $ref: "common.yaml#/components/responses/403"
+        '406':
+          $ref: "common.yaml#/components/responses/406"
+        '415':
+          $ref: 'common.yaml#/components/responses/415'
+        '429':
+          $ref: "common.yaml#/components/responses/429"
+        '500':
+          $ref: "common.yaml#/components/responses/500"
+        '503':
+          $ref: "common.yaml#/components/responses/503"
+        'default':
+          $ref: "common.yaml#/components/responses/default"
+      tags:
+        - BRP historie bevragen
+# Daar waar mogelijk wordt nu verwezen naar componenten die in HC BRP Personen zijn gedefinieerd. Dat is echter alleen mogelijk als betreffende componenten zelf niet ook een $ref bevatten.
+# Daar waar dat wel het geval is zijn de componenten in de openapi.yaml van HC BRP Historie gekopieerd.
+
+# De vraag is of dit de gewenste aanpak is of dat we alle componenten lokaal binnen de openapi.yaml van HC BRP Historie moeten definiëren.
+components:
+  schemas:
+    HistorieQuery:
+      type: object
+      required:
+        - type
+        - burgerservicenummer
+      discriminator:
+        propertyName: type
+        mapping:
+          RaadpleegMetPeildatum: '#/components/schemas/RaadpleegMetPeildatum'
+          RaadpleegMetPeriode: '#/components/schemas/RaadpleegMetPeriode'
+      properties:
+        type:
+          type: string
+        burgerservicenummer:
+          $ref: "persoon.yaml#/components/schemas/Burgerservicenummer"
+    RaadpleegMetPeildatum:
+      required:
+        - peildatum
+      allOf:
+        - $ref: '#/components/schemas/HistorieQuery'
+        - type: object
+          properties:
+            peildatum:
+              type: string
+              description: |
+                De datum waarop de resource wordt opgevraagd.
+              format: date
+              example: 1964-09-24
+    RaadpleegMetPeriode:
+      required:
+        - datumVan
+        - datumTot
+      allOf:
+        - $ref: '#/components/schemas/HistorieQuery'
+        - type: object
+          properties:
+            datumVan:
+              type: string
+              description: |
+                De begindatum van de periode waarover de resource wordt opgevraagd.
+              format: date
+              example: 1964-09-24
+            datumTot:
+              type: string
+              description: |
+                De einddatum van de periode waarover de resource wordt opgevraagd.
+              format: date
+              example: 1964-09-24
+    VerblijfplaatshistorieQueryResponse:
+      type: object
+      properties:
+        verblijfplaatsen:
+          type: array
+          items:
+            $ref: 'verblijfplaats-voorkomen.yaml#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+        opschortingBijhouding:
+          $ref: 'opschortingbijhouding.yaml#/components/schemas/OpschortingBijhouding'
+        geheimhoudingPersoonsgegevens:
+          $ref: 'persoon.yaml#/components/schemas/GeheimhoudingPersoonsgegevens'

--- a/modules/historie/attachments/openapi.yaml
+++ b/modules/historie/attachments/openapi.yaml
@@ -1,25 +1,27 @@
 openapi: 3.0.3
-servers:
-  - description: "RvIG Proefomgeving"
-    url: https://apigw.npr.idm.diginetwerk.net/lap/api/brp
 info:
   title: BRP historie bevragen
   description: |
-                API voor het zoeken en raadplegen van historische verblijfplaatsen, partners, nationaliteiten en verblijfstitels uit de BRP (inclusief de RNI).
+    API voor het zoeken en raadplegen van historische verblijfplaatsen, partners, nationaliteiten en verblijfstitels uit de BRP (inclusief de RNI).
 
-                Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/tree/v1.0.0/features) voor nadere toelichting.
-  version: 2.0.0
+    Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen/tree/v1.0.0/features) voor nadere toelichting.
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen
   license:
-    name: European Union Public License, version 1.2 (EUPL-1.2)
+    name: "European Union Public License, version 1.2 (EUPL-1.2)"
     url: https://eupl.eu/1.2/nl/
+  version: 2.0.0
+servers:
+- url: https://apigw.npr.idm.diginetwerk.net/lap/api/brp
+  description: RvIG Proefomgeving
 tags:
-  - name: BRP historie bevragen
-    description: Zoeken historische gegevens
+- name: BRP historie bevragen
+  description: Zoeken historische gegevens
 paths:
   /verblijfplaatshistorie:
     post:
+      tags:
+      - BRP historie bevragen
       description: |
         Raadpleeg de verblijfplaatshistorie van een persoon op de opgegeven peildatum of binnen de opgegeven periode.
         Het meest actuele adres staat bovenaan.
@@ -30,106 +32,959 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/HistorieQuery"
+              $ref: '#/components/schemas/HistorieQuery'
       responses:
-        '200':
+        "200":
           description: |
-                        Zoekactie geslaagd
+            Zoekactie geslaagd
           headers:
             warning:
-              $ref: "common.yaml#/components/headers/warning"
+              $ref: '#/components/headers/warning'
             X-Rate-Limit-Limit:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Limit"
+              $ref: '#/components/headers/X_Rate_Limit_Limit'
             X-Rate-Limit-Remaining:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Remaining"
+              $ref: '#/components/headers/X_Rate_Limit_Remaining'
             X-Rate-Limit-Reset:
-              $ref: "common.yaml#/components/headers/X_Rate_Limit_Reset"
+              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VerblijfplaatshistorieQueryResponse"
-        '400':
-          $ref: "common.yaml#/components/responses/400"
-        '401':
-          $ref: "common.yaml#/components/responses/401"
-        '403':
-          $ref: "common.yaml#/components/responses/403"
-        '406':
-          $ref: "common.yaml#/components/responses/406"
-        '415':
-          $ref: 'common.yaml#/components/responses/415'
-        '429':
-          $ref: "common.yaml#/components/responses/429"
-        '500':
-          $ref: "common.yaml#/components/responses/500"
-        '503':
-          $ref: "common.yaml#/components/responses/503"
-        'default':
-          $ref: "common.yaml#/components/responses/default"
-      tags:
-        - BRP historie bevragen
-# Daar waar mogelijk wordt nu verwezen naar componenten die in HC BRP Personen zijn gedefinieerd. Dat is echter alleen mogelijk als betreffende componenten zelf niet ook een $ref bevatten.
-# Daar waar dat wel het geval is zijn de componenten in de openapi.yaml van HC BRP Historie gekopieerd.
-
-# De vraag is of dit de gewenste aanpak is of dat we alle componenten lokaal binnen de openapi.yaml van HC BRP Historie moeten definiëren.
+                $ref: '#/components/schemas/VerblijfplaatshistorieQueryResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestFoutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+                title: Ten minste één parameter moet worden opgegeven.
+                status: 400
+                detail: The request could not be understood by the server due to malformed
+                  syntax. The client SHOULD NOT repeat the request without modification.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: paramsRequired
+                invalidParams:
+                - type: https://www.vng.nl/realisatie/api/validaties/integer
+                  name: huisnummer
+                  code: integer
+                  reason: Waarde is geen geldig getal.
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+                title: Niet correct geauthenticeerd.
+                status: 401
+                detail: The request requires user authentication. The response MUST
+                  include a WWW-Authenticate header field (section 14.47) containing
+                  a challenge applicable to the requested resource.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: authentication
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+                title: U bent niet geautoriseerd voor deze operatie.
+                status: 403
+                detail: "The server understood the request, but is refusing to fulfill\
+                  \ it."
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: autorisation
+        "406":
+          description: Not Acceptable
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+                title: Gevraagde contenttype wordt niet ondersteund.
+                status: 406
+                detail: The resource identified by the request is only capable of
+                  generating response entities which have content characteristics
+                  not acceptable according to thr accept headers sent in the request
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAcceptable
+        "415":
+          description: Unsupported Media Type
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
+                title: Unsupported Media Type
+                status: 415
+                detail: The server is refusing the request because the entity of the
+                  request is in a format not supported by the requested resource for
+                  the requested method.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: unsupported
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+                title: Too many request
+                status: 429
+                detail: The user has sent too many requests in a given amount of time
+                  (rate limiting).
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: tooManyRequests
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+                title: Interne server fout.
+                status: 500
+                detail: The server encountered an unexpected condition which prevented
+                  it from fulfilling the request.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: serverError
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
+              example:
+                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+                title: Bronservice BRP is tijdelijk niet beschikbaar.
+                status: 503
+                detail: The service is currently unable to handle the request due
+                  to a temporary overloading or maintenance of the server.
+                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+                code: notAvailable
+        default:
+          description: Er is een onverwachte fout opgetreden
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Foutbericht'
 components:
   schemas:
     HistorieQuery:
-      type: object
       required:
-        - type
-        - burgerservicenummer
+      - burgerservicenummer
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+        burgerservicenummer:
+          $ref: '#/components/schemas/Burgerservicenummer'
       discriminator:
         propertyName: type
         mapping:
           RaadpleegMetPeildatum: '#/components/schemas/RaadpleegMetPeildatum'
           RaadpleegMetPeriode: '#/components/schemas/RaadpleegMetPeriode'
-      properties:
-        type:
-          type: string
-        burgerservicenummer:
-          $ref: "persoon.yaml#/components/schemas/Burgerservicenummer"
     RaadpleegMetPeildatum:
       required:
-        - peildatum
+      - peildatum
       allOf:
-        - $ref: '#/components/schemas/HistorieQuery'
-        - type: object
-          properties:
-            peildatum:
-              type: string
-              description: |
-                De datum waarop de resource wordt opgevraagd.
-              format: date
-              example: 1964-09-24
+      - $ref: '#/components/schemas/HistorieQuery'
+      - type: object
+        properties:
+          peildatum:
+            type: string
+            description: |
+              De datum waarop de resource wordt opgevraagd.
+            format: date
+            example: 1964-09-24
     RaadpleegMetPeriode:
       required:
-        - datumVan
-        - datumTot
+      - datumTot
+      - datumVan
       allOf:
-        - $ref: '#/components/schemas/HistorieQuery'
-        - type: object
-          properties:
-            datumVan:
-              type: string
-              description: |
-                De begindatum van de periode waarover de resource wordt opgevraagd.
-              format: date
-              example: 1964-09-24
-            datumTot:
-              type: string
-              description: |
-                De einddatum van de periode waarover de resource wordt opgevraagd.
-              format: date
-              example: 1964-09-24
+      - $ref: '#/components/schemas/HistorieQuery'
+      - type: object
+        properties:
+          datumVan:
+            type: string
+            description: |
+              De begindatum van de periode waarover de resource wordt opgevraagd.
+            format: date
+            example: 1964-09-24
+          datumTot:
+            type: string
+            description: |
+              De einddatum van de periode waarover de resource wordt opgevraagd.
+            format: date
+            example: 1964-09-24
     VerblijfplaatshistorieQueryResponse:
       type: object
       properties:
         verblijfplaatsen:
           type: array
           items:
-            $ref: 'verblijfplaats-voorkomen.yaml#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+            $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
         opschortingBijhouding:
-          $ref: 'opschortingbijhouding.yaml#/components/schemas/OpschortingBijhouding'
+          $ref: '#/components/schemas/OpschortingBijhouding'
         geheimhoudingPersoonsgegevens:
-          $ref: 'persoon.yaml#/components/schemas/GeheimhoudingPersoonsgegevens'
+          $ref: '#/components/schemas/GeheimhoudingPersoonsgegevens'
+    BadRequestFoutbericht:
+      allOf:
+      - $ref: '#/components/schemas/Foutbericht'
+      - type: object
+        properties:
+          invalidParams:
+            type: array
+            description: Foutmelding per fout in een parameter. Alle gevonden fouten
+              worden één keer teruggemeld.
+            items:
+              $ref: '#/components/schemas/InvalidParams'
+    Foutbericht:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Link naar meer informatie over deze fout
+          format: uri
+        title:
+          pattern: "^[a-zA-Z0-9À-ž \\.\\-]{1,80}$"
+          type: string
+          description: Beschrijving van de fout
+        status:
+          maximum: 600
+          minimum: 100
+          type: integer
+          description: Http status code
+        detail:
+          pattern: "^[a-zA-Z0-9À-ž \\.\\-\\(\\)\\,]{1,200}$"
+          type: string
+          description: Details over de fout
+        instance:
+          type: string
+          description: Uri van de aanroep die de fout heeft veroorzaakt
+          format: uri
+        code:
+          minLength: 1
+          pattern: "^[a-zA-Z0-9]{1,25}$"
+          type: string
+          description: Systeemcode die het type fout aangeeft
+      description: "Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807)."
+    InvalidParams:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+          example: "https://www.vng.nl/realisatie/api/{major-versie}/validaties/integer"
+        name:
+          pattern: "^[a-zA-Z0-9\\.,_]{1,30}$"
+          type: string
+          description: Naam van de parameter
+          example: huisnummer
+        code:
+          minLength: 1
+          pattern: "^[a-zA-Z0-9\\.,_]{1,25}$"
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          example: integer
+        reason:
+          pattern: "^[a-zA-Z0-9\\.,_ ]{1,80}$"
+          type: string
+          description: Beschrijving van de fout op de parameterwaarde
+          example: Waarde is geen geldig getal.
+      description: Details over fouten in opgegeven parameters
+    Burgerservicenummer:
+      pattern: "^[0-9]{9}$"
+      type: string
+      example: "555555021"
+    AbstractVerblijfplaatsVoorkomen:
+      required:
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+      description: |
+        Gegevens over het verblijfplaats voorkomen van een persoon.
+      discriminator:
+        propertyName: type
+        mapping:
+          VerblijfplaatsBuitenland: '#/components/schemas/VerblijfplaatsBuitenlandVoorkomen'
+          Adres: '#/components/schemas/AdresVoorkomen'
+          VerblijfplaatsOnbekend: '#/components/schemas/VerblijfplaatsOnbekendVoorkomen'
+          Locatie: '#/components/schemas/LocatieVoorkomen'
+    VerblijfplaatsBuitenlandVoorkomen:
+      description: |
+        * **land** - land waar de persoon is overleden. Wordt gevuld met waarden uit de landelijke tabel 'Landen'.
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          verblijfadres:
+            $ref: '#/components/schemas/VerblijfadresBuitenland'
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          inOnderzoek:
+            $ref: '#/components/schemas/VerblijfplaatsBuitenlandVoorkomenInOnderzoek'
+          rni:
+            $ref: '#/components/schemas/RniDeelnemer'
+          adressering:
+            $ref: '#/components/schemas/AdresseringBuitenland'
+    VerblijfplaatsBuitenlandVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+          gemeenteVanInschrijving:
+            type: boolean
+    AdresVoorkomen:
+      description: |
+        Gegevens over het adres voorkomen van een persoon.
+        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
+        * **aanduidingBijHuisnummer** - wordt gevuld met waarden voor 'Aanduiding_Bij_Huisnummer' in 'tabelwaarden.csv'.
+        * **datumVan** : de datum van aangifte of ambtshalve melding van verblijf en adres.
+        * **datumTot** : de datum van aangifte of ambtshalve melding van volgende verblijf en adres.
+        * **verblijftNietOpAdresVanaf** : geeft aan op welke datum is vastgesteld dat de persoon niet langer op dit adres of deze locatie woont.
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          verblijfadres:
+            $ref: '#/components/schemas/VerblijfadresBinnenland'
+          functieAdres:
+            $ref: '#/components/schemas/Waardetabel'
+          adresseerbaarObjectIdentificatie:
+            $ref: '#/components/schemas/AdresseerbaarObjectIdentificatie'
+          nummeraanduidingIdentificatie:
+            $ref: '#/components/schemas/NummeraanduidingIdentificatie'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          verblijftNietOpAdresVanaf:
+            $ref: '#/components/schemas/AbstractDatum'
+          inOnderzoek:
+            $ref: '#/components/schemas/AdresVoorkomenInOnderzoek'
+          adressering:
+            $ref: '#/components/schemas/AdresseringBinnenland'
+    AdresVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          gemeenteVanInschrijving:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+          nummeraanduidingIdentificatie:
+            type: boolean
+          adresseerbaarObjectIdentificatie:
+            type: boolean
+          functieAdres:
+            type: boolean
+    VerblijfplaatsOnbekendVoorkomen:
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          inOnderzoek:
+            $ref: '#/components/schemas/VerblijfplaatsOnbekendVoorkomenInOnderzoek'
+          rni:
+            $ref: '#/components/schemas/RniDeelnemer'
+    VerblijfplaatsOnbekendVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+          gemeenteVanInschrijving:
+            type: boolean
+    LocatieVoorkomen:
+      description: |
+        * **functieAdres** - wordt gevuld met waarden voor 'Functie_Adres' in 'tabelwaarden.csv'.
+        * **gemeenteVanInschrijving** - wordt gevuld met waarden uit de landelijke tabel 'Gemeenten'.
+        * **verblijftNietOpAdresVanaf** : geeft aan op welke datum is vastgesteld dat de persoon niet langer op dit adres of deze locatie verblijft.
+      allOf:
+      - $ref: '#/components/schemas/AbstractVerblijfplaatsVoorkomen'
+      - type: object
+        properties:
+          datumVan:
+            $ref: '#/components/schemas/AbstractDatum'
+          datumTot:
+            $ref: '#/components/schemas/AbstractDatum'
+          functieAdres:
+            $ref: '#/components/schemas/Waardetabel'
+          verblijfadres:
+            $ref: '#/components/schemas/VerblijfadresLocatie'
+          gemeenteVanInschrijving:
+            $ref: '#/components/schemas/Waardetabel'
+          verblijftNietOpAdresVanaf:
+            $ref: '#/components/schemas/AbstractDatum'
+          inOnderzoek:
+            $ref: '#/components/schemas/LocatieVoorkomenInOnderzoek'
+          adressering:
+            $ref: '#/components/schemas/AdresseringBinnenland'
+    LocatieVoorkomenInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          type:
+            type: boolean
+          gemeenteVanInschrijving:
+            type: boolean
+          datumVan:
+            type: boolean
+          datumTot:
+            type: boolean
+          functieAdres:
+            type: boolean
+    OpschortingBijhouding:
+      allOf:
+      - $ref: '#/components/schemas/OpschortingBijhoudingBasis'
+      - type: object
+        properties:
+          datum:
+            $ref: '#/components/schemas/AbstractDatum'
+        description: |
+          * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
+    OpschortingBijhoudingBasis:
+      type: object
+      properties:
+        reden:
+          $ref: '#/components/schemas/Waardetabel'
+      description: |
+        * **reden** - wordt gevuld met waarden voor 'Reden_Opschorting_Bijhouding' in 'tabelwaarden.csv'.
+    GeheimhoudingPersoonsgegevens:
+      type: boolean
+      description: |
+        Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
+    VerblijfadresBuitenland:
+      type: object
+      properties:
+        regel1:
+          $ref: '#/components/schemas/Regel1'
+        regel2:
+          $ref: '#/components/schemas/Regel2'
+        regel3:
+          $ref: '#/components/schemas/Regel3'
+        land:
+          $ref: '#/components/schemas/Waardetabel'
+        inOnderzoek:
+          $ref: '#/components/schemas/VerblijfadresBuitenlandInOnderzoek'
+    Regel1:
+      maxLength: 40
+      type: string
+      description: |
+        Het eerste deel van een buitenlands adres. Vaak is dit een combinatie van de straat en huisnummer.
+      example: 1600 Pennsylvania Avenue NW
+    Regel2:
+      maxLength: 50
+      type: string
+      description: |
+        Het tweede deel van een buitenlands adres. Vaak is dit een combinatie van woonplaats eventueel in combinatie met de postcode.
+      example: "Washington, DC 20500"
+    Regel3:
+      maxLength: 35
+      type: string
+      description: |
+        Het derde deel van een buitenlands adres is optioneel. Het gaat om een of meer geografische gebieden van het adres in het buitenland.
+      example: Selangor
+    VerblijfadresBuitenlandInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          regel1:
+            type: boolean
+          regel2:
+            type: boolean
+          regel3:
+            type: boolean
+          land:
+            type: boolean
+    AbstractDatum:
+      required:
+      - langFormaat
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+        langFormaat:
+          pattern: "^[a-z0-9 ]{1,17}$"
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          Datum: '#/components/schemas/VolledigeDatum'
+          DatumOnbekend: '#/components/schemas/DatumOnbekend'
+          JaarDatum: '#/components/schemas/JaarDatum'
+          JaarMaandDatum: '#/components/schemas/JaarMaandDatum'
+    VolledigeDatum:
+      required:
+      - datum
+      description: Datum conform iso8601
+      example:
+        value:
+          type: Datum
+          datum: 2018-07-01
+          langFormaat: 1 juli 2018
+      allOf:
+      - $ref: '#/components/schemas/AbstractDatum'
+      - type: object
+        properties:
+          datum:
+            type: string
+            format: date
+    DatumOnbekend:
+      required:
+      - onbekend
+      description: representatie voor een volledig onbekend datum
+      example:
+        value:
+          type: DatumOnbekend
+          onbekend: true
+          langFormaat: onbekend
+      allOf:
+      - $ref: '#/components/schemas/AbstractDatum'
+      - type: object
+        properties:
+          onbekend:
+            type: boolean
+            default: true
+    JaarDatum:
+      required:
+      - jaar
+      description: representatie voor een datum waarvan maand en dag onbekend zijn
+      example:
+        value:
+          type: JaarDatum
+          jaar: 2018
+          langFormaat: 2018
+      allOf:
+      - $ref: '#/components/schemas/AbstractDatum'
+      - type: object
+        properties:
+          jaar:
+            $ref: '#/components/schemas/Jaar'
+    Jaar:
+      maximum: 9999
+      minimum: 1
+      type: integer
+      format: int32
+    JaarMaandDatum:
+      required:
+      - jaar
+      - maand
+      description: representatie voor een datum waarvan de dag onbekend is
+      example:
+        value:
+          type: JaarMaandDatum
+          jaar: 2018
+          maand: 7
+          langFormaat: juli 2018
+      allOf:
+      - $ref: '#/components/schemas/AbstractDatum'
+      - type: object
+        properties:
+          jaar:
+            $ref: '#/components/schemas/Jaar'
+          maand:
+            $ref: '#/components/schemas/Maand'
+    Maand:
+      maximum: 12
+      minimum: 1
+      type: integer
+      format: int32
+    Waardetabel:
+      type: object
+      properties:
+        code:
+          pattern: "^[a-zA-Z0-9 \\.]+$"
+          type: string
+          example: "6030"
+        omschrijving:
+          pattern: "^[a-zA-Z0-9À-ž \\'\\,\\(\\)\\.\\-]{1,200}$"
+          type: string
+          example: Nederland
+    RniDeelnemer:
+      type: object
+      properties:
+        deelnemer:
+          $ref: '#/components/schemas/Waardetabel'
+        omschrijvingVerdrag:
+          $ref: '#/components/schemas/OmschrijvingVerdrag'
+    OmschrijvingVerdrag:
+      pattern: "^[a-zA-Z0-9À-ž \\.\\-\\']{1,50}$"
+      type: string
+      description: |
+        Omschrijving van het verdrag op basis waarvan een zusterorganisatie in het buitenland de gegevens bij de RNI-deelnemer heeft aangeleverd.
+    AdresseringBuitenland:
+      type: object
+      properties:
+        adresregel1:
+          $ref: '#/components/schemas/Adresregel1'
+        adresregel2:
+          $ref: '#/components/schemas/Adresregel2'
+        adresregel3:
+          $ref: '#/components/schemas/Adresregel3'
+        land:
+          $ref: '#/components/schemas/Waardetabel'
+        inOnderzoek:
+          $ref: '#/components/schemas/AdresseringBuitenlandInOnderzoek'
+    Adresregel1:
+      maxLength: 40
+      type: string
+      description: |
+        Het eerste deel van een adres is een combinatie van de straat en huisnummer.
+      example: Kappeyne v d Cappellostr 26A-3
+    Adresregel2:
+      maxLength: 50
+      type: string
+      description: |
+        Het tweede deel van een adres is een combinatie van woonplaats eventueel in combinatie met de postcode.
+      example: 1234AA Nootdorp
+    Adresregel3:
+      maxLength: 35
+      type: string
+      description: |
+        Het derde deel van een adres is optioneel. Het gaat om een of meer geografische gebieden van het adres in het buitenland.
+      example: Selangor
+    AdresseringBuitenlandInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          adresregel1:
+            type: boolean
+          adresregel2:
+            type: boolean
+          adresregel3:
+            type: boolean
+          land:
+            type: boolean
+    InOnderzoek:
+      type: object
+      properties:
+        datumIngangOnderzoek:
+          $ref: '#/components/schemas/AbstractDatum'
+    VerblijfadresBinnenland:
+      type: object
+      properties:
+        officieleStraatnaam:
+          $ref: '#/components/schemas/OfficieleStraatnaam'
+        korteStraatnaam:
+          $ref: '#/components/schemas/KorteStraatnaam'
+        huisnummer:
+          $ref: '#/components/schemas/Huisnummer'
+        huisletter:
+          $ref: '#/components/schemas/Huisletter'
+        huisnummertoevoeging:
+          $ref: '#/components/schemas/Huisnummertoevoeging'
+        aanduidingBijHuisnummer:
+          $ref: '#/components/schemas/Waardetabel'
+        postcode:
+          $ref: '#/components/schemas/Postcode'
+        woonplaats:
+          $ref: '#/components/schemas/Woonplaats'
+        inOnderzoek:
+          $ref: '#/components/schemas/VerblijfadresBinnenlandInOnderzoek'
+    OfficieleStraatnaam:
+      maxLength: 80
+      type: string
+      description: |
+        De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG).
+    KorteStraatnaam:
+      maxLength: 24
+      type: string
+      description: |
+        De officiële naam van een openbare ruimte uit de Basisregistratie Gebouwen en Adressen (BAG), zo nodig verkort tot maximaal 24 tekens, of de straatnaam van een niet-BAG adres.
+    Huisnummer:
+      maximum: 99999
+      minimum: 1
+      type: integer
+      description: |
+        Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
+      example: 14
+    Huisletter:
+      pattern: "^[a-zA-Z]{1}$"
+      type: string
+      description: |
+        Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
+      example: a
+    Huisnummertoevoeging:
+      pattern: "^[a-zA-Z0-9 \\-]{1,4}$"
+      type: string
+      description: |
+        Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
+      example: bis
+    Postcode:
+      pattern: "^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$"
+      type: string
+      description: |
+        De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
+      example: 2341SX
+    Woonplaats:
+      title: woonplaats naam
+      pattern: "^[a-zA-Z0-9À-ž \\(\\)\\,\\.\\-\\']{1,80}$"
+      type: string
+      description: |
+        Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam.
+      example: Duiven
+    VerblijfadresBinnenlandInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          aanduidingBijHuisnummer:
+            type: boolean
+          huisletter:
+            type: boolean
+          huisnummer:
+            type: boolean
+          huisnummertoevoeging:
+            type: boolean
+          officieleStraatnaam:
+            type: boolean
+          postcode:
+            type: boolean
+          korteStraatnaam:
+            type: boolean
+          woonplaats:
+            type: boolean
+    AdresseerbaarObjectIdentificatie:
+      pattern: "^[0-9]{16}$"
+      type: string
+      description: |
+        De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
+      example: "0226010000038820"
+    NummeraanduidingIdentificatie:
+      pattern: "^[0-9]{16}$"
+      type: string
+      description: |
+        Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
+      example: "0518200000366054"
+    AdresseringBinnenland:
+      type: object
+      properties:
+        adresregel1:
+          $ref: '#/components/schemas/Adresregel1'
+        adresregel2:
+          $ref: '#/components/schemas/Adresregel2'
+        inOnderzoek:
+          $ref: '#/components/schemas/AdresseringBinnenlandInOnderzoek'
+    AdresseringBinnenlandInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          adresregel1:
+            type: boolean
+          adresregel2:
+            type: boolean
+    VerblijfadresLocatie:
+      type: object
+      properties:
+        locatiebeschrijving:
+          $ref: '#/components/schemas/Locatiebeschrijving'
+        inOnderzoek:
+          $ref: '#/components/schemas/VerblijfadresLocatieInOnderzoek'
+    Locatiebeschrijving:
+      maxLength: 35
+      type: string
+      description: |
+        Omschrijving van de ligging van een verblijfsobject, standplaats of ligplaats.
+      example: Naast de derde brug
+    VerblijfadresLocatieInOnderzoek:
+      allOf:
+      - $ref: '#/components/schemas/InOnderzoek'
+      - type: object
+        properties:
+          locatiebeschrijving:
+            type: boolean
+  responses:
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestFoutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1
+            title: Ten minste één parameter moet worden opgegeven.
+            status: 400
+            detail: The request could not be understood by the server due to malformed
+              syntax. The client SHOULD NOT repeat the request without modification.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: paramsRequired
+            invalidParams:
+            - type: https://www.vng.nl/realisatie/api/validaties/integer
+              name: huisnummer
+              code: integer
+              reason: Waarde is geen geldig getal.
+    "401":
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
+            title: Niet correct geauthenticeerd.
+            status: 401
+            detail: The request requires user authentication. The response MUST include
+              a WWW-Authenticate header field (section 14.47) containing a challenge
+              applicable to the requested resource.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: authentication
+    "403":
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4
+            title: U bent niet geautoriseerd voor deze operatie.
+            status: 403
+            detail: "The server understood the request, but is refusing to fulfill\
+              \ it."
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: autorisation
+    "406":
+      description: Not Acceptable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.7
+            title: Gevraagde contenttype wordt niet ondersteund.
+            status: 406
+            detail: The resource identified by the request is only capable of generating
+              response entities which have content characteristics not acceptable
+              according to thr accept headers sent in the request
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAcceptable
+    "415":
+      description: Unsupported Media Type
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.16
+            title: Unsupported Media Type
+            status: 415
+            detail: The server is refusing the request because the entity of the request
+              is in a format not supported by the requested resource for the requested
+              method.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: unsupported
+    "429":
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+            title: Too many request
+            status: 429
+            detail: The user has sent too many requests in a given amount of time
+              (rate limiting).
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: tooManyRequests
+    "500":
+      description: Internal Server Error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+            title: Interne server fout.
+            status: 500
+            detail: The server encountered an unexpected condition which prevented
+              it from fulfilling the request.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: serverError
+    "503":
+      description: Service Unavailable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
+            title: Bronservice BRP is tijdelijk niet beschikbaar.
+            status: 503
+            detail: The service is currently unable to handle the request due to a
+              temporary overloading or maintenance of the server.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAvailable
+    default:
+      description: Er is een onverwachte fout opgetreden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+  headers:
+    warning:
+      schema:
+        maxLength: 500
+        type: string
+        description: "zie RFC 7234. In het geval een major versie wordt uitgefaseerd,\
+          \ gebruiken we warn-code 299 (\"Miscellaneous Persistent Warning\") en het\
+          \ API end-point (inclusief versienummer) als de warn-agent van de warning,\
+          \ gevolgd door de warn-text met de human-readable waarschuwing"
+        example: "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd\
+          \ en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie\
+          \ hier de documentatie: https://omgevingswet.../api/.../v1\"."
+    X_Rate_Limit_Limit:
+      schema:
+        type: integer
+    X_Rate_Limit_Remaining:
+      schema:
+        type: integer
+    X_Rate_Limit_Reset:
+      schema:
+        type: integer

--- a/modules/historie/examples/features/raadpleeg-verblijfplaats-met-periode
+++ b/modules/historie/examples/features/raadpleeg-verblijfplaats-met-periode
@@ -1,0 +1,1 @@
+../../../../features/raadpleeg-verblijfplaats-met-periode

--- a/modules/historie/nav.adoc
+++ b/modules/historie/nav.adoc
@@ -1,0 +1,3 @@
+.Verblijfplaatshistorie
+* xref:historie:releasenotes.adoc[Releasenotes]
+* xref:historie:specificatie.adoc[Specificatie]

--- a/modules/historie/nav.adoc
+++ b/modules/historie/nav.adoc
@@ -1,3 +1,4 @@
 .Verblijfplaatshistorie
 * xref:historie:releasenotes.adoc[Releasenotes]
 * xref:historie:specificatie.adoc[Specificatie]
+* xref:historie:documentatie.adoc[Documentatie]

--- a/modules/historie/pages/documentatie.adoc
+++ b/modules/historie/pages/documentatie.adoc
@@ -1,0 +1,48 @@
+= {apiname} Verblijfplaatshistorie
+
+== Wat is verblijfplaatshistorie?
+Met de {{apiname}} Verblijfplaatshistorie kun je de verblijfplaats(en) van een persoon opvragen in een periode of op een peildatum. Je krijgt dan de verblijfplaats waarop de persoon woonde op de opgegeven peildatum, of alle verblijfplaatsen waar de persoon in de opgegeven periode heeft verbleven. Dat heb je bijvoorbeeld nodig als je moet uitzoeken welke gemeente de kosten van het verblijf van een persoon in een instelling moet dragen. Daarvoor moet je weten in welke gemeente de persoon woonde in de periode voor het verblijf in de instelling.
+
+== Wat heb je nodig?
+In de BRP worden personen uniek geïdentificeerd met behulp van hun burgerservicenummer. Dit 9-cijferige nummer gebruik je om aan te geven van welke persoon je de verblijfplaatsgegevens wilt opvragen.
+
+== Raadplegen van de verblijfplaats op een datum
+Raadpleeg op welke verblijfplaats een persoon verbleef op een specifieke datum door de operatie "RaadpleegMetPeildatum" en de parameter "peildatum" te gebruiken.
+
+Als je bijvoorbeeld wilt weten waar de persoon verbleef op 3 juli 2021 stuur je als request body:
+
+[source,json]
+----
+{
+  "burgerservicenummer": "999994669",
+  "type": "RaadpleegMetPeildatum",
+  "peildatum": "2021-07-03"
+}
+----
+
+== Raadplegen van de verblijfplaatsen gedurende een periode
+Raadpleeg op welke verblijfplaats(en) een persoon verbleef tijdens een periode door de operatie "RaadpleegMetPeriode" en parameters "datumVan" en "datumTot" te gebruiken.
+
+Als je bijvoorbeeld wilt weten waar de persoon verbleef tussen 3 juli 2021 en 8 oktober 2022 stuur je als request body:
+
+[source,json]
+----
+{
+  "burgerservicenummer": "999994669",
+  "type": "RaadpleegMetPeriode",
+  "datumVan": "2021-07-03",
+  "datumTot": "2022-10-08"
+}
+----
+
+Het resultaat bevat alle verblijfplaatsen waar de persoon tijdens de periode minimaal 1 dag stond ingeschreven. 
+Verblijfplaatsen worden gesorteerd geleverd, zodat de meest actuele verblijfplaats de eerste is in de lijst.
+
+== Afleidingsregels
+De regels voor het opnemen van verblijfplaatsen op basis van opgegeven "datumVan" en "datumTot" volgen binnenkort.
+
+Lees hier hoe de {apiname} Verblijfplaatshistorie xref:historie:features/raadpleeg-verblijfplaats-met-periode/verblijfplaatsgegevens.adoc[omgaat met verschillende typen verblijfplaatsen] 
+Bij elke verblijfplaats is "datumVan" (de begindatum van het verblijf) in het antwoord opgenomen. Wanneer de persoon er nu niet meer verblijft is "datumTot" opgenomen als de datum dat de persoon er niet meer verblijft. Lees hier de xref:historie:features/raadpleeg-verblijfplaats-met-periode/datum-van-en-tot.adoc[regels voor het leveren van datumVan en datumTot].
+
+=== Vastgesteld verblijft niet op adres
+Als je verblijfplaatsgegevens en/of adresregels vraagt van persoon die niet meer verblijft op het geregistreerde adres, dan wordt het *indicatieVastgesteldVerblijftNietOpAdres* veld met waarde true meegeleverd. Dit betekent dat tijdens een onderzoek naar de verblijfplaats van de persoon is gebleken dat de persoon niet op dit adres woont. Lees hier hoe het xref:historie:features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.adoc[indicatieVastgesteldVerblijftNietOpAdres veld wordt bepaald].

--- a/modules/historie/pages/features/raadpleeg-verblijfplaats-met-periode/datum-van-en-tot.adoc
+++ b/modules/historie/pages/features/raadpleeg-verblijfplaats-met-periode/datum-van-en-tot.adoc
@@ -1,0 +1,4 @@
+[source,gherkin]
+----
+include::example$features/raadpleeg-verblijfplaats-met-periode/datum-van-en-tot.feature[]
+----

--- a/modules/historie/pages/features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.adoc
+++ b/modules/historie/pages/features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.adoc
@@ -1,0 +1,4 @@
+[source,gherkin]
+----
+include::example$features/raadpleeg-verblijfplaats-met-periode/vastgesteld-verblijft-niet-op-adres.feature[]
+----

--- a/modules/historie/pages/features/raadpleeg-verblijfplaats-met-periode/verblijfplaatsgegevens.adoc
+++ b/modules/historie/pages/features/raadpleeg-verblijfplaats-met-periode/verblijfplaatsgegevens.adoc
@@ -1,0 +1,4 @@
+[source,gherkin]
+----
+include::example$features/raadpleeg-verblijfplaats-met-periode/verblijfplaatsgegevens.feature[]
+----

--- a/modules/historie/pages/releasenotes.adoc
+++ b/modules/historie/pages/releasenotes.adoc
@@ -1,4 +1,4 @@
-= Releasenotes Haal-Centraal-BRP-historie-bevragen
+= Releasenotes
 
 == Versie 1.0.0
 
@@ -7,70 +7,67 @@ Dit is een globaal overzicht van wijzigingen die daarvoor zijn doorgevoerd.
 
 We bieden bieden een link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen/tree/master/test[postman-collectie] t.b.v. testen aan.
 
-=== Openapi.yaml :
+=== Openapi.yaml:
 
-****Breaking:****
+*Breaking:*
 
-- Enkele parameternamen zijn aangepast vanwege consistentie met andere Haal-Centraal API's en/of de Design Decision om parameternamen in camelCase op te nemen  
-  - datumvan --> datumVan
-  - datumtotenmet --> datumTotEnMet  
+- Enkele parameternamen zijn aangepast vanwege consistentie met andere Haal-Centraal API's en/of de Design Decision om parameternamen in camelCase op te nemen
+  * datumvan -> datumVan
+  * datumtotenmet -> datumTotEnMet  
 
-  - Enkele property-namen zijn gewijzigd
-    - Nationaliteithistorie.datumEindeGeldigheid --> Nationaliteithistorie.datumTot
-    - Verblijfplaatshistorie_links.nummeraanduiding --> VerblijfplaatshistorieLinks.adres
-    - Verblijfplaats is anders opgebouwd.
-      - Schema-component BinnenlandsAdres is verwijderd. Er wordt nu hergebruik gemaakt van het component Adres en dat wordt direct aangevuld met de properties
-        - BinnenlandsAdres.openbareRuimteNaam --> Verblijfplaats.straat
-        - BinnenlandsAdres.functieAdres --> Verblijfplaats.functieAdres
-        - BinnenlandsAdres.aanduidingBijHuisnummer --> Verblijfplaats.aanduidingBijHuisnummer
-        - BinnenlandsAdres.identificatiecodeNummeraanduiding --> Verblijfplaats.nummeraanduidingIdentificatie
-        - BinnenlandsAdres.woonplaatsnaam --> Verblijfplaats.woonplaats
-        - Verblijfplaats.identificatiecodeVerblijfplaats --> Verblijfplaats.identificatiecodeAdresseerbaarObject --> Verblijfplaats.adresseerbaarObjectIdentificatie
-        - Verblijfplaats.straatnaam --> Verblijfplaats.korteNaam
-        - component verblijfBuitenland is komen te vervallen.
-      - Schema-component Verblijfbuitenland is verwijderd. Properties zijn opgenomen in Verblijfplaats en enkele zijn hernoemd.
-        - VerblijfBuitenland.adresRegel1 --> Verblijfplaats.adresregel1
-        - VerblijfBuitenland.adresRegel2 --> Verblijfplaats.adresregel2  
-        - VerblijfBuitenland.adresRegel3 --> Verblijfplaats.adresregel3  
-        - VerblijfBuitenland.vertrokkenOnbekendWaarheen --> Verblijfplaats.vertrokkenOnbekendWaarheen
-        - VerblijfBuitenland.land --> Verblijfplaats.land
-      - VerblijfplaatsInOnderzoek.identificatiecodeNummeraanduiding --> VerblijfplaatsInOnderzoek.nummeraanduidingIdentificatie
-      - VerblijfplaatsInOnderzoek.identificatiecodeVerblijfplaats --> VerblijfplaatsInOnderzoek.identificatiecodeAdresseerbaarObject --> VerblijfplaatsInOnderzoek.adresseerbaarObjectIdentificatie
-      - VerblijfplaatsInOnderzoek.straatnaam --> VerblijfplaatsInOnderzoek.korteNaam
-      - VerblijfplaatsInOnderzoek.naamOpenbareRuimte --> VerblijfplaatsInOnderzoek.straat
-      - VerblijfplaatsInOnderzoek.woonplaatsnaam --> VerblijfplaatsInOnderzoek.woonplaats
+- Enkele property-namen zijn gewijzigd
+  * Nationaliteithistorie.datumEindeGeldigheid -> Nationaliteithistorie.datumTot
+  * Verblijfplaatshistorie_links.nummeraanduiding -> VerblijfplaatshistorieLinks.adres
 
+- Verblijfplaats is anders opgebouwd.
+  * Schema-component BinnenlandsAdres is verwijderd. Er wordt nu hergebruik gemaakt van het component Adres en dat wordt direct aangevuld met de properties
+    ** BinnenlandsAdres.openbareRuimteNaam -> Verblijfplaats.straat
+    ** BinnenlandsAdres.functieAdres -> Verblijfplaats.functieAdres
+    ** BinnenlandsAdres.aanduidingBijHuisnummer -> Verblijfplaats.aanduidingBijHuisnummer
+    ** BinnenlandsAdres.identificatiecodeNummeraanduiding -> Verblijfplaats.nummeraanduidingIdentificatie
+    ** BinnenlandsAdres.woonplaatsnaam -> Verblijfplaats.woonplaats
+    ** Verblijfplaats.identificatiecodeVerblijfplaats -> Verblijfplaats.identificatiecodeAdresseerbaarObject -> Verblijfplaats.adresseerbaarObjectIdentificatie
+    ** Verblijfplaats.straatnaam -> Verblijfplaats.korteNaam
+    ** component verblijfBuitenland is komen te vervallen.
+  * Schema-component Verblijfbuitenland is verwijderd. Properties zijn opgenomen in Verblijfplaats en enkele zijn hernoemd.
+    ** VerblijfBuitenland.adresRegel1 -> Verblijfplaats.adresregel1
+    ** VerblijfBuitenland.adresRegel2 -> Verblijfplaats.adresregel2  
+    ** VerblijfBuitenland.adresRegel3 -> Verblijfplaats.adresregel3  
+    ** VerblijfBuitenland.vertrokkenOnbekendWaarheen -> Verblijfplaats.vertrokkenOnbekendWaarheen
+    ** VerblijfBuitenland.land -> Verblijfplaats.land
+    ** VerblijfplaatsInOnderzoek.identificatiecodeNummeraanduiding -> VerblijfplaatsInOnderzoek.nummeraanduidingIdentificatie
+    ** VerblijfplaatsInOnderzoek.identificatiecodeVerblijfplaats -> VerblijfplaatsInOnderzoek.identificatiecodeAdresseerbaarObject -> VerblijfplaatsInOnderzoek.adresseerbaarObjectIdentificatie
+    ** VerblijfplaatsInOnderzoek.straatnaam -> VerblijfplaatsInOnderzoek.korteNaam
+    ** VerblijfplaatsInOnderzoek.naamOpenbareRuimte -> VerblijfplaatsInOnderzoek.straat
+    ** VerblijfplaatsInOnderzoek.woonplaatsnaam -> VerblijfplaatsInOnderzoek.woonplaats
 
-  - Verwijderde properties:
-    - Verblijfstitelhistorie.indicatieVerblijfstitelBeeindigd
-    - Verblijfstitel.datumOpneming
-    - VerblijfstitelInOnderzoek.datumOpneming
+- Verwijderde properties:
+  * Verblijfstitelhistorie.indicatieVerblijfstitelBeeindigd
+  * Verblijfstitel.datumOpneming
+  * VerblijfstitelInOnderzoek.datumOpneming
 
+*Non-breaking:*
 
-
-****Non-breaking:****
-- server-url is aangepast (omdat het een aparte API is geworden.) --> link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen
+- server-url is aangepast (omdat het een aparte API is geworden.) -> link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen
 - OperationId's zijn aangepast ivm code-generatie issues en nu in UpperCamelCase.
 - Bij properties zijn de maxLength, minLength, pattern en (waar overbodig) de title weggehaald.
 
 - Schema-component Burgerservicenummer is verwijderd. De properties die deze als $REF gebruikten zijn als string gedefinieerd.
 
-
 - Enkele namen van schema-componenten zijn aangepast vanwege consistentie met andere Haal-Centraal API's
-  - NationaliteithistorieHalCollectie__embedded --> NationaliteithistorieHalCollectieEmbedded
-  - Verwijzing naar common-schemacomponent Datum_onvolledig --> DatumOnvolledig
-  - VerblijfplaatshistorieHalCollectie__embedded --> VerblijfplaatshistorieHalCollectieEmbedded
-  - Verblijfplaatshistorie_links --> VerblijfplaatshistorieLinks
-  - PartnerhistorieHalCollectie__embedded --> PartnerhistorieHalCollectieEmbedded
-  - Partnerhistorie_links --> PartnerhistorieLinks
-  - VerblijfstitelhistorieHalCollectie__embedded --> VerblijfstitelhistorieHalCollectieEmbedded
-  - AangaanHuwelijkInOnderzoek --> AangaanHuwelijkPartnerschapInOnderzoek
+  * NationaliteithistorieHalCollectie__embedded -> NationaliteithistorieHalCollectieEmbedded
+  * Verwijzing naar common-schemacomponent Datum_onvolledig -> DatumOnvolledig
+  * VerblijfplaatshistorieHalCollectie__embedded -> VerblijfplaatshistorieHalCollectieEmbedded
+  * Verblijfplaatshistorie_links -> VerblijfplaatshistorieLinks
+  * PartnerhistorieHalCollectie__embedded -> PartnerhistorieHalCollectieEmbedded
+  * Partnerhistorie_links -> PartnerhistorieLinks
+  * VerblijfstitelhistorieHalCollectie__embedded -> VerblijfstitelhistorieHalCollectieEmbedded
+  * AangaanHuwelijkInOnderzoek -> AangaanHuwelijkPartnerschapInOnderzoek
 
 - Toegevoegde properties:
-  - OntbindingHuwelijkInOnderzoek.reden is toegevoegd
-  - OntbindingHuwelijk.indicatieHuwelijkPartnerschapBeeindigd is toegevoegd
-  - Partnerhistorie.naam.adellijkeTitelPredikaat is toegevoegd
-
+  * OntbindingHuwelijkInOnderzoek.reden is toegevoegd
+  * OntbindingHuwelijk.indicatieHuwelijkPartnerschapBeeindigd is toegevoegd
+  * Partnerhistorie.naam.adellijkeTitelPredikaat is toegevoegd
 
 === Features:
 

--- a/modules/historie/pages/releasenotes.adoc
+++ b/modules/historie/pages/releasenotes.adoc
@@ -1,0 +1,86 @@
+= Releasenotes Haal-Centraal-BRP-historie-bevragen
+
+== Versie 1.0.0
+
+Alhoewel er nog geen eerdere officiële versie van de Haal-Centraal-BRP-historie-bevragen API als release is uitgebracht zijn de specificaties van deze endpoints als onderdeel van de specificatie van Haal-Centraal-BRP-bevragen het afgelopen jaar beschikbaar geweest via de repository. In de https://github.com/BRP-API/Haal-Centraal-BRP-bevragen/tree/v0.9.0[v0.9.0 release van BRP-bevragen] zijn de historie-endpoints nog opgenomen. In de afgelopen maanden hebben we de historie-endpoints in een aparte API ondergebracht. Daarbij zijn nieuwe inzichten die het afgelopen jaar zijn opgedaan opgenomen. Recentelijk hebben we de specificaties ook aangepast op het hergebruik van componenten uit BRP-Bevragen release 1.2.0.
+Dit is een globaal overzicht van wijzigingen die daarvoor zijn doorgevoerd.
+
+We bieden bieden een link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen/tree/master/test[postman-collectie] t.b.v. testen aan.
+
+=== Openapi.yaml :
+
+****Breaking:****
+
+- Enkele parameternamen zijn aangepast vanwege consistentie met andere Haal-Centraal API's en/of de Design Decision om parameternamen in camelCase op te nemen  
+  - datumvan --> datumVan
+  - datumtotenmet --> datumTotEnMet  
+
+  - Enkele property-namen zijn gewijzigd
+    - Nationaliteithistorie.datumEindeGeldigheid --> Nationaliteithistorie.datumTot
+    - Verblijfplaatshistorie_links.nummeraanduiding --> VerblijfplaatshistorieLinks.adres
+    - Verblijfplaats is anders opgebouwd.
+      - Schema-component BinnenlandsAdres is verwijderd. Er wordt nu hergebruik gemaakt van het component Adres en dat wordt direct aangevuld met de properties
+        - BinnenlandsAdres.openbareRuimteNaam --> Verblijfplaats.straat
+        - BinnenlandsAdres.functieAdres --> Verblijfplaats.functieAdres
+        - BinnenlandsAdres.aanduidingBijHuisnummer --> Verblijfplaats.aanduidingBijHuisnummer
+        - BinnenlandsAdres.identificatiecodeNummeraanduiding --> Verblijfplaats.nummeraanduidingIdentificatie
+        - BinnenlandsAdres.woonplaatsnaam --> Verblijfplaats.woonplaats
+        - Verblijfplaats.identificatiecodeVerblijfplaats --> Verblijfplaats.identificatiecodeAdresseerbaarObject --> Verblijfplaats.adresseerbaarObjectIdentificatie
+        - Verblijfplaats.straatnaam --> Verblijfplaats.korteNaam
+        - component verblijfBuitenland is komen te vervallen.
+      - Schema-component Verblijfbuitenland is verwijderd. Properties zijn opgenomen in Verblijfplaats en enkele zijn hernoemd.
+        - VerblijfBuitenland.adresRegel1 --> Verblijfplaats.adresregel1
+        - VerblijfBuitenland.adresRegel2 --> Verblijfplaats.adresregel2  
+        - VerblijfBuitenland.adresRegel3 --> Verblijfplaats.adresregel3  
+        - VerblijfBuitenland.vertrokkenOnbekendWaarheen --> Verblijfplaats.vertrokkenOnbekendWaarheen
+        - VerblijfBuitenland.land --> Verblijfplaats.land
+      - VerblijfplaatsInOnderzoek.identificatiecodeNummeraanduiding --> VerblijfplaatsInOnderzoek.nummeraanduidingIdentificatie
+      - VerblijfplaatsInOnderzoek.identificatiecodeVerblijfplaats --> VerblijfplaatsInOnderzoek.identificatiecodeAdresseerbaarObject --> VerblijfplaatsInOnderzoek.adresseerbaarObjectIdentificatie
+      - VerblijfplaatsInOnderzoek.straatnaam --> VerblijfplaatsInOnderzoek.korteNaam
+      - VerblijfplaatsInOnderzoek.naamOpenbareRuimte --> VerblijfplaatsInOnderzoek.straat
+      - VerblijfplaatsInOnderzoek.woonplaatsnaam --> VerblijfplaatsInOnderzoek.woonplaats
+
+
+  - Verwijderde properties:
+    - Verblijfstitelhistorie.indicatieVerblijfstitelBeeindigd
+    - Verblijfstitel.datumOpneming
+    - VerblijfstitelInOnderzoek.datumOpneming
+
+
+
+****Non-breaking:****
+- server-url is aangepast (omdat het een aparte API is geworden.) --> link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen
+- OperationId's zijn aangepast ivm code-generatie issues en nu in UpperCamelCase.
+- Bij properties zijn de maxLength, minLength, pattern en (waar overbodig) de title weggehaald.
+
+- Schema-component Burgerservicenummer is verwijderd. De properties die deze als $REF gebruikten zijn als string gedefinieerd.
+
+
+- Enkele namen van schema-componenten zijn aangepast vanwege consistentie met andere Haal-Centraal API's
+  - NationaliteithistorieHalCollectie__embedded --> NationaliteithistorieHalCollectieEmbedded
+  - Verwijzing naar common-schemacomponent Datum_onvolledig --> DatumOnvolledig
+  - VerblijfplaatshistorieHalCollectie__embedded --> VerblijfplaatshistorieHalCollectieEmbedded
+  - Verblijfplaatshistorie_links --> VerblijfplaatshistorieLinks
+  - PartnerhistorieHalCollectie__embedded --> PartnerhistorieHalCollectieEmbedded
+  - Partnerhistorie_links --> PartnerhistorieLinks
+  - VerblijfstitelhistorieHalCollectie__embedded --> VerblijfstitelhistorieHalCollectieEmbedded
+  - AangaanHuwelijkInOnderzoek --> AangaanHuwelijkPartnerschapInOnderzoek
+
+- Toegevoegde properties:
+  - OntbindingHuwelijkInOnderzoek.reden is toegevoegd
+  - OntbindingHuwelijk.indicatieHuwelijkPartnerschapBeeindigd is toegevoegd
+  - Partnerhistorie.naam.adellijkeTitelPredikaat is toegevoegd
+
+
+=== Features:
+
+De feature files hebben als doel om functioneel de werking te beschrijven.
+
+- nationaliteithistorie.feature is verplaatst naar link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen[Haal-Centraal-BRP-historie-bevragen]
+- partnerhistorie.feature is verplaatst naar link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen[Haal-Centraal-BRP-historie-bevragen]
+- verblijfplaatshistorie.feature is verplaatst naar link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen[Haal-Centraal-BRP-historie-bevragen]
+- verblijfstitelhistorie.feature is verplaatst naar link:https://github.com/BRP-API/Haal-Centraal-BRP-historie-bevragen[Haal-Centraal-BRP-historie-bevragen]
+- onvolledige_datum.feature is verplaatst naar link:https://github.com/VNG-Realisatie/Haal-Centraal-common/tree/v1.2.0/features[Common]
+- fields.feature is verplaatst naar link:https://github.com/VNG-Realisatie/Haal-Centraal-common/tree/v1.2.0/features[Common]
+- foutafhandeling.feature is verplaatst naar link:https://github.com/VNG-Realisatie/Haal-Centraal-common/tree/v1.2.0/features[Common]
+- links.feature is verplaatst naar link:https://github.com/VNG-Realisatie/Haal-Centraal-common/tree/v1.2.0/features[Common]

--- a/modules/historie/pages/specificatie.adoc
+++ b/modules/historie/pages/specificatie.adoc
@@ -1,0 +1,9 @@
+++++
+  <redoc id='redoc-container'></redoc>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.64/bundles/redoc.standalone.js"></script>
+  <script>
+    Redoc.init('./_attachments/openapi.yaml',
+    {scrollYOffset: '.toolbar'},
+    document.getElementById('redoc-container'))
+  </script>
+++++

--- a/modules/historie/pages/specificatie.adoc
+++ b/modules/historie/pages/specificatie.adoc
@@ -1,9 +1,7 @@
 ++++
-  <redoc id='redoc-container'></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.64/bundles/redoc.standalone.js"></script>
-  <script>
-    Redoc.init('./_attachments/openapi.yaml',
-    {scrollYOffset: '.toolbar'},
-    document.getElementById('redoc-container'))
-  </script>
+<redoc id='redoc-container'></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.64/bundles/redoc.standalone.js"></script>
+<script>
+  Redoc.init('../_attachments/openapi.yaml', {scrollYOffset: '.toolbar'}, document.getElementById('redoc-container'))
+</script>
 ++++


### PR DESCRIPTION
Dit PR voegt de benodigde configuratie en content toe om de documentatie m.b.t. _Verblijfplaatshistorie_ te publiceren.

De volgende pagina's zijn toegevoegd:
- Releasenotes
- Specificatie (Redoc)
- Features
    - Raadpleeg verblijfplaats met periode
        - datum van en tot
        - vastgesteld verblijft niet op adres
        - verblijfplaatsgegevens

Zie https://brp-api.github.io/devportal-poc/brp-api/historie/releasenotes.html